### PR TITLE
Fix broken links. Add link checker for dev

### DIFF
--- a/book.json
+++ b/book.json
@@ -9,7 +9,9 @@
         "-mermaid-2",
         "toolbar@git+https://github.com/hamishwillee/gitbook-plugin-toolbar.git",
         "language-picker",
-        "custom-favicon"
+        "custom-favicon",
+        "-stub-out-blocks@git+https://github.com/hamishwillee/gitbook-plugin-stub-out-blocks.git",
+        "-validate-links"
     ],
     "pluginsConfig": {
         "theme-api": {

--- a/en/README.md
+++ b/en/README.md
@@ -2,7 +2,7 @@
 
 MAVLink is a very lightweight, header-only message marshalling library for micro air vehicles / drones.
 
-MAVLink follows a modern hybrid publish-subscribe and point-to-point design pattern: Data streams are sent / published as **topics** while configuration sub-protocols such as the [mission protocol](/mission-protocol.md) or [parameter protocol](/parameter-protocol.md) are point-to-point with retransmission.
+MAVLink follows a modern hybrid publish-subscribe and point-to-point design pattern: Data streams are sent / published as **topics** while configuration sub-protocols such as the [mission protocol](mission_protocol.md) or [parameter protocol](parameter_protocol.md) are point-to-point with retransmission.
 
 Because MAVLink doesn't require any additional framing it is very well suited for applications with very limited communication bandwidth. It's reference implementation in C/C++ is highly optimized for resource-constrained systems with limited RAM and flash memory. It is field-proven and deployed in many products where it serves as interoperability interface between components of different manufacturers.
 

--- a/en/protocol.md
+++ b/en/protocol.md
@@ -1,6 +1,6 @@
 # Protocol Overview
 
-MAVLink is a binary telemetry protocol designed for resource-constrained systems and bandwidth-constrained links. MAVLink is deployed in two major versions: v1.0 and v2.0, which is backwards-compatible \(v2.0 implementations can parse and send v1.0 packets\). Telemetry data streams are sent in a multicast design while protocol aspects that change the system configuration and require guaranteed delivery like the [mission protocol](/mission-protocol.md) or [parameter protocol](/parameter-protocol.md) are point-to-point with retransmission.
+MAVLink is a binary telemetry protocol designed for resource-constrained systems and bandwidth-constrained links. MAVLink is deployed in two major versions: v1.0 and v2.0, which is backwards-compatible \(v2.0 implementations can parse and send v1.0 packets\). Telemetry data streams are sent in a multicast design while protocol aspects that change the system configuration and require guaranteed delivery like the [mission protocol](mission_protocol.md) or [parameter protocol](parameter_protocol.md) are point-to-point with retransmission.
 
 ## MAVLink 1 Packet Format
 


### PR DESCRIPTION
This fixes broken links. 

It also adds these two plugins to **book.json** that can be used to allow link checking on Windows.

The two plugins are disabled by default (see the preceding "-")
```
"-stub-out-blocks@git+https://github.com/hamishwillee/gitbook-plugin-stub-out-blocks.git",
"-validate-links"
```
* The **validate-links** plugin generates a list of broken links when you run `gitbook serve`. It is disabled by default because it causes the build to fail on gitbook.com or linux builds. 
* The **stub-out-blocks** plugin provides an empty implementation for mermaid tags. This is useful on Windows, where mermaid has lots of installation issues. If you disable mermaid and enable this then you can do build testing of everything except mermaid on Windows.

So, to use this during testing (on windows) you simply enable the two plugins (remove the "-") and disable mermaid.