### PR TITLE
[WIP] MAVLink Generator doc from old site

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -24,11 +24,13 @@
   * [paparazzi.xml](messages/paparazzi.md)
   * [ualberta.xml](messages/ualberta.md)
   * [uAvionix.xml](messages/uAvionix.md)
+  * [icarous.xml](messages/icarous.md)
   * [standard.xml](messages/standard.md)
   * [test.xml](messages/test.md)
   * [python_array_test.xml](messages/python_array_test.md)
   * [slugs.xml](messages/slugs.md)
 * [Arm Authorization](arm_authorization.md)
+* [MAVLink Generator](mavlink_generator.md)
 
 
 ----

--- a/en/mavlink_generator.md
+++ b/en/mavlink_generator.md
@@ -1,19 +1,17 @@
 # MAVLink Generator (C/C++, Python)
 
-MAVLink is distributed with a common set of messages. Custom messages can be generated and included as a replacement for the common message set or as extension to it. See the minimal.xml for a minimal example and pixhawk.xml for an example of using the common message set with some project-specific extensions.
+MAVLink is distributed with a common set of messages. Custom messages can be generated and included as a replacement for the common message set or as extension to it. See the [minimal.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/minimal.xml) for a minimal example and [uAvionix.xml](https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/uAvionix.xml) for an example of using the common message set with some project-specific extensions.
 
 Download the generator from here: https://github.com/mavlink/mavlink
 
-Then run:
+To obtain the generator GUI run:
 
 ```sh
 python mavgenerate.py
 ```
  
-To obtain the generator GUI.
-
-Generator Steps
-1. Load XML file, from mavlink/message_definitions
-1. Select output directory, e.g. mavlink/include
-1. Click “Generate”
-1. Use the new headers in your project
+Generator Steps:
+1. Load XML file, from [mavlink/message_definitions](https://github.com/mavlink/mavlink/tree/master/message_definitions)
+1. Select output directory, e.g. *mavlink/include*.
+1. Click **Generate**.
+1. Use the new headers in your project.

--- a/en/mavlink_generator.md
+++ b/en/mavlink_generator.md
@@ -1,0 +1,19 @@
+# MAVLink Generator (C/C++, Python)
+
+MAVLink is distributed with a common set of messages. Custom messages can be generated and included as a replacement for the common message set or as extension to it. See the minimal.xml for a minimal example and pixhawk.xml for an example of using the common message set with some project-specific extensions.
+
+Download the generator from here: https://github.com/mavlink/mavlink
+
+Then run:
+
+```sh
+python mavgenerate.py
+```
+ 
+To obtain the generator GUI.
+
+Generator Steps
+1. Load XML file, from mavlink/message_definitions
+1. Select output directory, e.g. mavlink/include
+1. Click “Generate”
+1. Use the new headers in your project

--- a/kr/SUMMARY.md
+++ b/kr/SUMMARY.md
@@ -23,6 +23,7 @@
   * [paparazzi.xml](messages/paparazzi.md)
   * [ualberta.xml](messages/ualberta.md)
   * [uAvionix.xml](messages/uAvionix.md)
+  * [icarous.xml](messages/icarous.md)
   * [standard.xml](messages/standard.md)
   * [test.xml](messages/test.md)
   * [python_array_test.xml](messages/python_array_test.md)


### PR DESCRIPTION
This imports MAVLink generator docs from http://qgroundcontrol.org/mavlink/generator and does basic fixes. 

Actions
* [x] After this approved: Copy new file in to /kr tree.
* [x] After this merged: delete  http://qgroundcontrol.org/mavlink/generator