### PR TITLE
Clarify that MAVLink2 only supported for C

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -28,6 +28,7 @@ Library definitions can be generated for the following programming languages:
 * Swift
 * Python (2.7+, 3.3+)
 
+> **Caution** At time of writing (Feb 2018) only generated C source fully supports MAVLink 2. Generated source for other programming languages only support MAVLink 1.0.
 
 ## Forums and Chat {#support}
 


### PR DESCRIPTION
According to https://github.com/ArduPilot/pymavlink/issues/151#issuecomment-367160812 only the C generated source is fully ported to MAVLink 2. Java is in progress and the rest have nothing. This note is supposed to make that clarification.

I'd also like to add this same caution at the end of the https://mavlink.io/en/getting_started/generate_source.html#generating-source-files topic.

This is waiting for (hopefully) some issue numbers I can add for tracking MAVLink 2 support for the other languages.  - FYI @magicrub