### PR TITLE
Clarify MAV version to programming lang version (C++11)

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -16,10 +16,14 @@ MAVLink was first released early 2009 by Lorenz Meier and has now a [significant
 
 ## Supported Languages {#supported_languages}
 
-Library definitions can be generated for the following programming languages:
+MAVLink 2 source files can be generated for:
 
 * C
 * C++11
+
+MAVLink 1 source files can be generated for:
+
+* C
 * C#
 * Objective C
 * Java
@@ -28,7 +32,6 @@ Library definitions can be generated for the following programming languages:
 * Swift
 * Python (2.7+, 3.3+)
 
-> **Caution** At time of writing (Feb 2018) only generated C source fully supports MAVLink 2. Generated source for other programming languages only support MAVLink 1.0.
 
 ## Forums and Chat {#support}
 

--- a/en/getting_started/generate_source.md
+++ b/en/getting_started/generate_source.md
@@ -1,7 +1,7 @@
 # Generating Source Files
 
 Language-specific files can be generated using a Python script from the command line or via a GUI. 
-Available languages include C, C#, Java, Python etc. (for a full list see [Introduction > Supported Languages](../README.md#supported_languages)).
+The available languages for each version of the MAVLink protocol are listed in [Introduction > Supported Languages](../README.md#supported_languages) (these include C, C#, Java, Python etc).
 
 > **Note** The tools must already have been set up as described in [Getting Started > Installation](../getting_started/README.md#install) section (in particular *Tkinter* must be installed to use the GUI tool).
 
@@ -23,7 +23,8 @@ Generator Steps:
 1. Choose the target XML file (typically in [mavlink/message_definitions](https://github.com/mavlink/mavlink/tree/master/message_definitions)).
 1. Choose an output directory (e.g. **mavlink/include**).
 1. Select the target output programming language.
-1. Select the target MAVLink protocol version (ideally 2.0).
+1. Select the target MAVLink protocol version (ideally 2.0)
+   > **Caution** Generation will fail if the protocol is not [supported](../README.md#supported_languages) by the selected programming language.
 1. Optionally check *Validate* and/or  *Validate Units* (if checked validates XML specifications).
 1. Click **Generate** to create the source files.
 

--- a/kr/README.md
+++ b/kr/README.md
@@ -12,6 +12,25 @@ MAVLink는 매우 제한된 통신 대역을 가지는 어플리케이션에 최
 MAVLink는 2009년 로렌츠 마이어(Lorenz Meier)가 처음 릴리즈하였고 지금은 [많은 컨트리뷰터들](https://github.com/mavlink/mavlink/graphs/contributors)이 있습니다.
 
 
+## Supported Languages {#supported_languages}
+
+MAVLink 2 source files can be generated for:
+
+* C
+* C++11
+
+MAVLink 1 source files can be generated for:
+
+* C
+* C#
+* Objective C
+* Java
+* JavaScript
+* Lua
+* Swift
+* Python (2.7+, 3.3+)
+
+
 ## Forums and Chat {#support}
 
 The core development team and community are active on the following chat channel:

--- a/kr/getting_started/generate_source.md
+++ b/kr/getting_started/generate_source.md
@@ -1,7 +1,7 @@
 # Generating Source Files
 
 Language-specific files can be generated using a Python script from the command line or via a GUI. 
-Available languages include C, C#, Java, Python etc. (for a full list see [Introduction > Supported Languages](../README.md#supported_languages)).
+The available languages for each version of the MAVLink protocol are listed in [Introduction > Supported Languages](../README.md#supported_languages) (these include C, C#, Java, Python etc).
 
 > **Note** The tools must already have been set up as described in [Getting Started > Installation](../getting_started/README.md#install) section (in particular *Tkinter* must be installed to use the GUI tool).
 
@@ -23,7 +23,8 @@ Generator Steps:
 1. Choose the target XML file (typically in [mavlink/message_definitions](https://github.com/mavlink/mavlink/tree/master/message_definitions)).
 1. Choose an output directory (e.g. **mavlink/include**).
 1. Select the target output programming language.
-1. Select the target MAVLink protocol version (ideally 2.0).
+1. Select the target MAVLink protocol version (ideally 2.0)
+   > **Caution** Generation will fail if the protocol is not [supported](../README.md#supported_languages) by the selected programming language.
 1. Optionally check *Validate* and/or  *Validate Units* (if checked validates XML specifications).
 1. Click **Generate** to create the source files.
 


### PR DESCRIPTION
This addresses https://github.com/mavlink/mavlink-devguide/pull/45#issuecomment-367252349 comment that C++11 *only* supports MAVLink 2. 

To make this clear and scalable as more language support is added I have separated the supported languages by protocol. I have also updated getting started to make it clear that if the programming language doesn't support the selected version then generation will fail. 

I'll merge this immediately. 