### PR TITLE
Clarify deep nesting of message files is not tested

### DIFF
--- a/en/messages/README.md
+++ b/en/messages/README.md
@@ -7,8 +7,11 @@ The common messages are provided as human-readable tables in: [Common](../messag
 
 ## Vendor Specific Extensions (Dialects) {#dialects}
 
-MAVLink protocol-specific and vendor-specific messages (dialects) are stored in separate XML files. These often extend (include) the [common](../messages/common.md) messages.
+MAVLink protocol-specific and vendor-specific messages (dialects) are stored in separate XML files. These often include the [common](../messages/common.md) message definition, extending it with needed vendor or protocol specific messages. 
 
+> **Note** While a dialect can include any other message definition, care should be taken when including a definition file that includes another file (only a single level of nesting is tested).
+
+<span></span>
 > **Note** Vendor forks of MAVLink may contain messages that are not yet merged, and hence will not appear in this documentation.
 
 The human-readable forms of the vendor XML files are linked below:


### PR DESCRIPTION
There was a case where a dialect had a single message and included the standard dialect (which includes common). The resulting `MAVLINK_MESSAGE_CRCS` only contained one entry. And only having one entry causes the CRC extras search to fail, even though we were actually trying to transmit the one message who's CRC was still there.

Upshot double-include is not properly supported, at least for all edge cases. This note aims to make that clear that there are potential problems, without having to debug them.

* [ ] When this is approved I will need to update the script that generates this page. Doing it here first as easy way to get PR discussed.