### PR TITLE
Add c_uart example to docs

### DIFF
--- a/en/getting_started/examples_scripts.md
+++ b/en/getting_started/examples_scripts.md
@@ -1,6 +1,26 @@
 # Scripts/Examples
 
-This MAVLink library also comes with supporting libraries and scripts for using, manipulating, and parsing MAVLink streams within the **pymavlink**, **pymavlink/tools**, and **pymavlink/examples** directories.
+## MAVLink C-UART Interface Example
+
+The [C-UART Interface Example](https://github.com/mavlink/c_uart_interface_example) is a simple C example of a MAVLink to UART interface for Unix-like systems.
+
+The example source code demonstrates how to set up serial communication between Pixhawk and an offboard computer via USB or a telemetry radio, how to put the vehicle in offboard mode, and how to send and receive MAVLink messages over the interface.
+
+Source code and instructions for how to run the example can be found in the Github repo: [mavlink/c_uart_interface_example](https://github.com/mavlink/c_uart_interface_example)
+
+
+## MAVLink UDP Example
+
+The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/linux) is a simple C example of a MAVLink UDP interface for Unix-like systems.
+
+The example sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program. 
+
+Source code and instructions for how to run the example can be found in the Github repo here: [mavlink/mavlink/examples/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+
+
+## Pymavlink Scripts
+
+This MAVLink library also comes with supporting libraries and scripts for using, manipulating, and parsing MAVLink streams within the [pymavlink](https://github.com/mavlink/pymavlink/), **pymavlink/tools**, and **pymavlink/examples** directories.
 
 The scripts have the following requirements:
 * Python 2.7+ and 3.3+

--- a/en/getting_started/installation.md
+++ b/en/getting_started/installation.md
@@ -1,6 +1,6 @@
 # Installing MAVLink
 
-This topic explains how to install the MAVLink toolchain, 
+This topic explains how to install the [MAVLink toolchain](https://github.com/mavlink/mavlink), 
 including both [XML message definitions](../messages/README.md) and the GUI/command line tools that use them to [Generate MAVLink Source Files](../getting_started/generate_source.md).
 
 > **Tip** If you are using [Prebuilt MAVLink Source Files](../README.md#prebuilt_libraries) you do not need to install or generate the source files. After getting the libraries see [Using Generated Source Files](../getting_started/use_source.md).
@@ -42,7 +42,7 @@ The main installation steps are:
       sudo apt-get install python-tk
       ```
 
-1. Clone the mavlink repo (or your fork) into a user-writable directory:
+1. Clone the [mavlink repo](https://github.com/mavlink/mavlink) (or your fork) into a user-writable directory:
    ```
    git clone https://github.com/mavlink/mavlink.git
    git submodule update --init --recursive


### PR DESCRIPTION
This addresses #55 by adding https://github.com/mavlink/c_uart_interface_example to the docs. It also adds https://github.com/mavlink/mavlink/tree/master/examples/linux

@LorenzMeier I decided to put this in the existing Scripts/Examples folder under "Getting Started". I think this is the right place for it because you'd want to discover this pretty early. 

Arguably it could be at the same level, immediately below Getting Started. I would put it there if we had more examples, and a number of examples that were beyond "getting started". Let me know if you think that is better.