### PR TITLE
Further tidy/clarification of serialization section

### DIFF
--- a/en/about/faq.md
+++ b/en/about/faq.md
@@ -36,6 +36,14 @@
 
   <dt>Why is the sequence number in the MAVLink header needed?</dt>
   <dd>MAVLink is part of the safety critical components of an unmanned air system. A bad communication link dropping many packets can endanger the flight safety of the aircraft and has to be monitored. Having the sequence in the header allows MAVLink to continuously provide feedback about the packet drop rate and thus allows the aircraft or ground control station to take action.</dd>
+  
+  <dt>Why is CRC_EXTRA needed in the packet checksum?</dt>
+  <dd>The CRC_EXTRA CRC is used to verify that the sender and receiver have a shared understanding of the over-the-wire format of a particular message 
+  (required because as a lightweight protocol, the message structure isn't included in the payload).
+  <br><br>
+  In MAVLink 0.9 the CRC was not used (although there was a length check). 
+  There were a small number of cases where XML describing a message changed without changing the message length, 
+  leading to badly corrupted fields when messages were read.</dd>
 
   <dt>I would like to help improve the decoding/encoding routines or other features. Can MAVLink be changed?</dt>
   <dd>Yes, but only very, very carefully with safety testing. 


### PR DESCRIPTION
This essentially targets the topic towards mavlink generator creators (ie not so much for users). 
It makes certain sections more readable - in particular the explanation of CRC extra and the message reordering.

There are a few outstanding questions:
1. Why does MAVLink 2 NOT reorder fields for new messages/extension fields - for MAVLink 1 this was considered very important for data alignment. Seems inconsistent.
1. CRC_EXTRA appears not to apply to extension messages. Why? See https://github.com/ArduPilot/pymavlink/issues/196
1. How does packet truncation work? I understand that biggest array is moved to end, and if end is zero filled it gets truncated. ... but then am confused about this being moved, since everything else indicates that fields aren't reordered in mavlink 2. Please clarify?
1. Is there any other truncation that takes place (other than zeros on end of arrays).