### PR TITLE
[WIP] File formats

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -21,7 +21,11 @@
     * [Arm Authorization Protocol](protocol/arm_authorization.md)
     * [Image Transmission Protocol](protocol/image_transmission.md)
     * [File Transfer Protocol (FTP)](protocol/ftp.md)
-    
+  * [File Formats](file_formats/README.md)
+    * [Mission Plan](file_formats/mission_plan.md)
+    * [GeoFence Plan](file_formats/geofence.md)
+    * [Rally/Safe Points Plan](file_formats/rally_points.md)
+    * [Mission Text Plan (Deprecated)](file_formats/mission_plan_plain_text.md)
   * [Message Signing](guide/message_signing.md)
   * [Serialization](guide/serialization.md)
   * [Routing](guide/routing.md)

--- a/en/file_formats/README.md
+++ b/en/file_formats/README.md
@@ -1,0 +1,15 @@
+# File Formats
+
+The MAVLink project standardizes a number of file formats to make it easier for MAVLink-based systems to store, reuse and share system information.
+This includes data for missions, geofence points, rally points, parameters etc.
+
+> **Tip** Most file formats have been implemented in the [QGroundControl reference implementation](http://github.com/mavlink/qgroundcontrol)
+
+The file format is usually JSON, and shares a close mapping to the structure of its associated message data.
+This allows easy conversion between message and file formats.
+The files may however include additional metadata that is not serialized over the link, but which is useful for GCS systems or other end users.
+
+* [Mission Plan](../file_formats/mission_plan.md)
+* [GeoFence Plan](../file_formats/geofence.md)
+* [Rally/Safe Points Plan](../file_formats/rally_points.md)
+* [Mission Text Plan (Deprecated)](../file_formats/mission_plan_plain_text.md)

--- a/en/file_formats/geofence.md
+++ b/en/file_formats/geofence.md
@@ -1,0 +1,80 @@
+# GeoFence Plan File Format (Mission Protocol)
+
+GeoFence plan files are formatted using JSON, and can defined a cyclindrical geofence using parameters <!-- (autopilot-specific?) --> and/or an arbitrary polygon.
+
+<!--  doc originates from *QGroundControl Dev Guide*: https://dev.qgroundcontrol.com/en/file_formats/fence.html -->
+
+```
+{
+    "fileType": "GeoFence",
+    "groundStation": "QGroundControl",
+    "parameters": [
+        {
+            "compId": 1,
+            "name": "FENCE_ENABLE",
+            "value": 1
+        },
+        {
+            "compId": 1,
+            "name": "FENCE_TYPE",
+            "value": 4
+        },
+        {
+            "compId": 1,
+            "name": "FENCE_ACTION",
+            "value": 0
+        },
+        {
+            "compId": 1,
+            "name": "FENCE_ALT_MAX",
+            "value": 0
+        },
+        {
+            "compId": 1,
+            "name": "FENCE_RADIUS",
+            "value": 0
+        },
+        {
+            "compId": 1,
+            "name": "FENCE_MARGIN",
+            "value": 0
+        }
+    ],
+    "polygon": [
+        [
+            47.634457973002796,
+            -122.08958864075316
+        ],
+        [
+            47.634371216366716,
+            -122.08675086361541
+        ],
+        [
+            47.632610748511105,
+            -122.08689033848418
+        ],
+        [
+            47.632610748511105,
+            -122.08967983585967
+        ]
+    ],
+    "version": 1
+}
+```
+
+The main fields are:
+
+Key | Description
+--- | ---
+fileType | Must be `GeoFence`
+version | The file-format version. Current version is 1.
+groundStation | The name of the ground station that created this file.
+parameters | A list of parameters for a cylindrical geofence.
+polygon | A list of points that define the boundary of the polygonal geofence.
+
+
+<!-- Add info here about params and polygon -->
+<!-- are the names - arbitrary - ie this is PX4 - what if you put same plan on ArduPilot - is it just set parameters? What is compid? -->
+<!-- do polygon points have to be in order and define an encircled area? -->
+<!-- are polygon points really in []  - normally in JSON the list is [] and items are inside  {} -->
+<!-- Do polygon just map to https://mavlink.io/en/messages/common.html#MISSION_ITEM  x, y, values? What about height of polygon? -->

--- a/en/file_formats/mission_plan.md
+++ b/en/file_formats/mission_plan.md
@@ -1,0 +1,168 @@
+# Mission/Flight-Plan File Format (Mission Protocol)
+
+Mission/Flight-Plan files are formatted using JSON, and contain both the mission and associated (optional) geo-fence and rally-point information.
+
+<!-- > doc originates from https://dev.qgroundcontrol.com/en/file_formats/plan.html -->
+
+## Plan (Top Level) {#plan}
+
+The top level structure of the plan file is shown below. 
+
+```
+{
+    "fileType": "Plan",
+    "version": 1
+    "groundStation": "QGroundControl",
+    "mission": {
+        "version": 2
+        "firmwareType": 12,
+        "vehicleType": 2,
+        "cruiseSpeed": 15,
+        "hoverSpeed": 5,
+        "plannedHomePosition": [
+            47.632939716176864,
+            -122.08905141,
+            40
+        ],
+        "items": [
+            ...
+        ],
+    },
+    "geoFence": {
+        ...
+    },
+    "rallyPoints": {
+        ...
+    },
+}
+```
+
+The main fields are:
+
+Key | Description
+--- | ---
+fileType | Must be `Plan`.
+version | The file-format version. Current version is 1.
+groundStation | The name of the ground station that created this file.
+[mission](#mission) | The mission associated with this flight plan.
+[geoFence](#geoFence) (Optional)| The geofence information associated with this flight plan.
+[rallyPoints](#rallyPoints) (Optional) | The rally (safe) points associated with this flight plan.
+
+
+## Mission Object {#mission}
+
+The following values are required:
+
+Key | Description
+--- | ---
+version | The version of the mission object. Current version is 2.
+firmwareType | The firmware type for which this mission was created. This is one of the [MAV_AUTOPILOT](../messages/common.md#MAV_AUTOPILOT) enum values. 
+vehicleType | The vehicle type for which this mission was created. This is one of the [MAV_TYPE](../messages/common.md#MAV_TYPE) enum values.
+cruiseSpeed | The default cruise speed for the mission (metres/second).
+hoverSpeed | The default hover speed for the mission (metres/second). <!-- what is hover speed? Only for Planes? What if on a still-hover system like MC) -->
+plannedHomePosition | The planned home position to show on the map when you are editing the mission. Values with array are latitude, longitude and altitude.
+items | The list of mission item objects associated with the mission. Each item will either be a [SimpleItem](#SimpleItem) or [ComplexItem](#ComplexItem). <!-- can you mix them? -->
+
+### Mission Item Object (SimpleItem) {#SimpleItem}
+
+A simple item represents a [MISSION_ITEM](../messages/common.md#MISSION_ITEM) command.
+
+```
+{
+    "autoContinue": true,
+    "command": 22,
+    "frame": 2,
+    "params": [
+        0,
+        0,
+        0,
+        0,
+        47.633127690000002,
+        -122.08867133,
+        50
+    ],
+    "type": "SimpleItem"
+},
+```
+
+The values in a `SimpleItem` map directly to the values in [MISSION_ITEM](../messages/common.md#MISSION_ITEM):
+
+Key | Description
+--- | ---
+type | `SimpleItem` (or `ComplexItem` for [complex items](#ComplexItem))
+autoContinue | [MISSION_ITEM](../messages/common.md#MISSION_ITEM).autoContinue
+command | [MISSION_ITEM](../messages/common.md#MISSION_ITEM).command
+frame | [MISSION_ITEM](../messages/common.md#MISSION_ITEM).frame
+params | [MISSION_ITEM](../messages/common.md#MISSION_ITEM).param1,2,3,4,x,y,z
+
+
+#### Special handling for DO_JUMP mission item
+
+Since `DO_JUMP` command requires you to specify the sequence number to jump to and the mission file format does not specify sequence numbers it requires special handling.
+
+First you must assign a unique identifier to the mission item you want to jump to:
+
+```
+{
+    ...
+    "doJumpId": 100
+}
+```
+
+The `doJumpId` can be any value greater than 0 and must uniquely identify a `DO_JUMP `target.
+
+Then in the actual `DO_JUMP` mission item you reference this unique id in the `SimpleItem.params` "param1" value (corresponding to `MISSION_ITEM.param1`):
+
+```
+{
+    ...
+    "command": 177,
+    "params": [
+        100,
+        ...
+    ],
+    ...
+},
+```
+
+When the mission is loaded the actual `DO_JUMP` sequence number will be determined and filled in.
+
+
+### Mission Item Object (ComplexItem) {#ComplexItem}
+
+A complex item is a higher level encapsulation of multiple [MISSION_ITEM](../messages/common.md#MISSION_ITEM) treated as a single entity.
+
+```
+{
+    "complexItemType": "survey",
+    "type": "ComplexItem",
+    "version": 3,
+    ...
+},
+```
+Complex items have two additional values associated with them:
+
+Key | Description
+--- | ---
+complexItemType | Specifies the type of complex item. QGroundControl currently supports the following types: [survey] <!-- (../file_formats/survey.md) -->, fwLandingPattern
+version | Specifies the version for this complex item.
+
+<!-- What of this is "standard", and what is PX4 stuff? -->
+<!-- Is survey format part of the standard?? -->
+
+
+## GeoFence Object {#geoFence}
+
+The (optional) geofence information associated with this flight plan has the same format as defined in [GeoFence Plan](../file_formats/geofence.md)
+(but omits the `fileType` and `groundStation` fields).
+
+<!-- confirm -->
+
+ 
+## Rally Points Object {#rallyPoints}
+ 
+The rally (safe) points associated with this flight plan have the same format as defined in [Rally/Safe Points Plan](../file_formats/rally_points.md).
+(but omits the `fileType` and `groundStation` fields).
+
+
+<!-- confirm -->

--- a/en/file_formats/mission_plan_plain_text.md
+++ b/en/file_formats/mission_plan_plain_text.md
@@ -1,0 +1,21 @@
+# Mission Plain-Text File Format (Deprecated)
+
+*QGroundControl* and many other GCS support an older plain-text format for missions. 
+This is not officially part of MAVLink and does not allow rally point or geofence information to be provided.
+
+> **Note** Where possible you should instead use the [Mission Plan](../file_formats/mission_plan.md) file format.
+
+The format is shown below. 
+Note that the spaces between the numbers/fields are actually `<tab>` (Use `\t` in most programming languages):
+
+```
+QGC WPL <VERSION>
+<INDEX> <CURRENT WP> <COORD FRAME> <COMMAND> <PARAM1> <PARAM2> <PARAM3> <PARAM4> <PARAM5/X/LONGITUDE> <PARAM6/Y/LATITUDE> <PARAM7/Z/ALTITUDE> <AUTOCONTINUE>
+Example
+QGC WPL 110
+0	1	0	16	0.149999999999999994	0	0	0	8.54800000000000004	47.3759999999999977	550	1
+1	0	0	16	0.149999999999999994	0	0	0	8.54800000000000004	47.3759999999999977	550	1
+2	0	0	16	0.149999999999999994	0	0	0	8.54800000000000004	47.3759999999999977	550	1
+```
+
+

--- a/en/file_formats/rally_points.md
+++ b/en/file_formats/rally_points.md
@@ -1,0 +1,51 @@
+# Rally (Safe) Point Plan File Format (Mission Protocol)
+
+Rally point plan files are formatted using JSON, and contain information about safe points.
+
+<!--  doc originates from *QGroundControl Dev Guide*: https://dev.qgroundcontrol.com/en/file_formats/rally.html -->
+
+
+```
+{
+    "fileType": "RallyPoints",
+    "groundStation": "QGroundControl",
+    "points": [
+        [
+            47.634309760000001,
+            -122.08936869999999,
+            50
+        ],
+        [
+            47.634244700000004,
+            -122.08700836,
+            50
+        ],
+        [
+            47.632784270000002,
+            -122.08712101,
+            50
+        ],
+        [
+            47.632769809999999,
+            -122.08939552,
+            50
+        ]
+    ],
+    "version": 1
+}
+```
+
+The main fields are:
+
+Key | Description
+--- | ---
+fileType | Must be `RallyPoints`
+version | The file-format version. Current version is 1.
+groundStation | The name of the ground station that created this file.
+points | A list of rally points. 
+
+
+<!-- Add info here about points -->
+<!-- do polygon points have to be in order and define an encircled area? -->
+<!-- are rally points list items really in [] - normally in JSON the list is [] and items are inside  {} -->
+<!-- Do points just map to https://mavlink.io/en/messages/common.html#MISSION_ITEM  x, y, z values? -->


### PR DESCRIPTION
This adds file format doc from https://dev.qgroundcontrol.com/en/file_formats/ - updated.
Some of these things were already documented (partially) so I am assuming we want these to be used as a standard.

@DonLakeFlyer @LorenzMeier Once stuff is standardised here, would link to it from QGC Devguide, removing duplication.

Some questions:
1. Is the survey format intended to also be "standardized"?
2. I saved a mission plan out of QGC where I had also defined a geofence and rally points. The geofence and rally point lists in the saved plan were empty lists. Do I need to do anything else to export these?
3. What is the geofence/rally point "intention"? Are these associated with the mission (- ie if we get RTL vehicle goes to THIS rally point rather than some other set) or are they just part of a single set of points used by the vehicle for everything?
4. Similarly, it looks like you can generate standalone geofence and rally point plans. How do I do this? If we don't allow generation, do we support import of them?

I will add few other questions inline.