### PR TITLE
Remove contributor info from Autopilots

### DIFF
--- a/en/about/ecosystem.md
+++ b/en/about/ecosystem.md
@@ -7,9 +7,9 @@ A non-exhaustive list of some users/contributors of this project is given below.
 
 The following autopilots are known to support MAVLink and are actively being developed (last release less than a year ago).
 
-* [PX4](http://px4.io/) (creator of the protocol)
-* [ArduPilot](http://ardupilot.org/) (key contributor to the protocol)
-* [AutoQuad 6 AutoPilot](http://autoquad.org) (contributor)
+* [PX4](http://px4.io/)
+* [ArduPilot](http://ardupilot.org/)
+* [AutoQuad 6 AutoPilot](http://autoquad.org)
 * [iNAV](https://github.com/iNavFlight/inav/wiki)
 * [SmartAP Autopilot](http://www.sky-drones.com/)
 


### PR DESCRIPTION
Removed contribution information from alongside autopilots. 
- If we want to have contributor information then IMO we link to Github data on this for mavlink/mavlink and ArduPilot/pymavlink.
- If we want to specifically call out a few projects, then let's do it in a separate heading. 
