### PR TITLE
Move MAVLink 2 content around

### DIFF
--- a/en/about/overview.md
+++ b/en/about/overview.md
@@ -6,7 +6,8 @@ MAVLink is deployed in two major versions: v1.0 and v2.0, which is backwards-com
 
 ## MAVLink 2 Packet Format
 
-Below is the over-the-wire format for a MAVLink 2 packet. The in-memory representation might differ.
+Below is the over-the-wire format for a [MAVLink v2](../guide/mavlink_2.md) packet. 
+The in-memory representation might differ.
 
 ```C
 uint8_t magic;              ///< protocol magic marker
@@ -26,7 +27,8 @@ uint16_t checksum;          ///< X.25 CRC
 uint8_t signature[13];      ///< Signature which allows ensuring that the link is tamper-proof (optional)
 ```
 
-> **Note** The [MAVLink 1 packet format](guide/serialization.md#v1_packet_format) is similar, but omits `incompat_flags`, `compat_flags` and `signature`, and only has a single byte for the message address.
+> **Note** The [MAVLink 1 packet format](../guide/serialization.md#v1_packet_format) is similar, but omits `incompat_flags`, `compat_flags` and `signature`, and only has a single byte for the message address.
+  For more information see [Serialization > Packet Format](../guide/serialization.md#packet_format).
 
 
 ## Serialization

--- a/en/about/overview.md
+++ b/en/about/overview.md
@@ -1,21 +1,7 @@
 # Protocol Overview
 
-MAVLink is a binary telemetry protocol designed for resource-constrained systems and bandwidth-constrained links. MAVLink is deployed in two major versions: v1.0 and v2.0, which is backwards-compatible \(v2.0 implementations can parse and send v1.0 packets\). Telemetry data streams are sent in a multicast design while protocol aspects that change the system configuration and require guaranteed delivery like the [mission protocol](../services/mission.md) or [parameter protocol](../services/parameter.md) are point-to-point with retransmission.
-
-## MAVLink 1 Packet Format
-
-Below is the over-the-wire format for a MAVLink 1 packet. The in-memory representation might differ.
-
-```C
-uint8_t magic;               ///< protocol magic marker
-uint8_t len;                 ///< Length of payload
-uint8_t seq;                 ///< Sequence of packet
-uint8_t sysid;               ///< ID of message sender system/aircraft
-uint8_t compid;              ///< ID of the message sender component
-uint8_t msgid;               ///< ID of message in payload
-uint8_t payload[max 255];    ///< A maximum of 255 payload bytes
-uint16_t checksum;           ///< X.25 CRC
-```
+MAVLink is a binary telemetry protocol designed for resource-constrained systems and bandwidth-constrained links. 
+MAVLink is deployed in two major versions: v1.0 and v2.0, which is backwards-compatible (v2.0 implementations can parse and send v1.0 packets). Telemetry data streams are sent in a multicast design while protocol aspects that change the system configuration and require guaranteed delivery like the [mission protocol](../services/mission.md) or [parameter protocol](../services/parameter.md) are point-to-point with retransmission.
 
 
 ## MAVLink 2 Packet Format
@@ -40,31 +26,40 @@ uint16_t checksum;          ///< X.25 CRC
 uint8_t signature[13];      ///< Signature which allows ensuring that the link is tamper-proof (optional)
 ```
 
+> **Note** The [MAVLink 1 packet format](guide/serialization.md#v1_packet_format) is similar, but omits `incompat_flags`, `compat_flags` and `signature`, and only has a single byte for the message address.
+
 
 ## Serialization
 
-The over-the-wire format of MAVLink is optimized for resource-constrained systems and hence the field order is not the same as in the XML specification. The over-the-wire generator sorts all fields of the message according to size, with the largest fields (`uint64_t`) first, then down to smaller fields. The sorting is done using a [stable sorting algorithm](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability), which ensures that any fields that do not need to be reordered stay in the same relative order. This prevents alignment issues on the encoding / decoding systems and allows for very efficient packing / unpacking.
+The over-the-wire format of MAVLink is optimized for resource-constrained systems and hence the field order is not the same as in the XML specification. 
+The over-the-wire generator sorts all fields of the message according to size, with the largest fields (`uint64_t`) first, then down to smaller fields. 
+The sorting is done using a [stable sorting algorithm](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability), which ensures that any fields that do not need to be reordered stay in the same relative order. 
+This prevents alignment issues on the encoding / decoding systems and allows for very efficient packing / unpacking.
 
 For more information and specific exceptions see [Serialization](../guide/serialization.md).
 
 
 ## Multicast Streams vs. Guaranteed Delivery
 
-MAVLink is built for hybrid networks where high-rate data streams from data sources \(commonly drones\) flow to data sinks \(commonly ground stations\), but are mixed with transfers requiring guaranteed delivery. The key insight is that for most **telemetry streams** there is not a known or single recipient: Instead, typically an onboard computer, a ground control station and a cloud system all need the same data stream.
+MAVLink is built for hybrid networks where high-rate data streams from data sources (commonly drones) flow to data sinks (commonly ground stations), but are mixed with transfers requiring guaranteed delivery. 
+The key insight is that for most **telemetry streams** there is not a known or single recipient: Instead, typically an onboard computer, a ground control station and a cloud system all need the same data stream.
 
-On the other hand configuring the **onboard mission** or changing the system configuration with **onboard parameters** requires point-to-point communication with guaranteed delivery. MAVLink achieves very high efficiency by allowing both modes of operation.
+On the other hand configuring the **onboard mission** or changing the system configuration with **onboard parameters** requires point-to-point communication with guaranteed delivery. 
+MAVLink achieves very high efficiency by allowing both modes of operation.
 
 ## Topic Mode \(publish-subscribe\)
 
-In topic mode the protocol will not emit a target system and component ID for messages to save link bandwidth. Typical examples for this communication mode are all autopilot data streams like position, attitude, etc.
+In topic mode the protocol will not emit a target system and component ID for messages to save link bandwidth. 
+Typical examples for this communication mode are all autopilot data streams like position, attitude, etc.
 
 The main benefit of this multicast mode is that no additional overhead is generated and multiple subscribers can all receive this data.
 
 ## Point-to-Point Mode
 
-In point-to-point mode MAVLink uses a target ID and target component. In most cases where these fields are used the sub-protocol also ensures guaranteed delivery \(missions, parameters, commands\).
+In point-to-point mode MAVLink uses a target ID and target component. 
+In most cases where these fields are used the sub-protocol also ensures guaranteed delivery (missions, parameters, commands).
 
 ## Integrity Checks / Checksum
 
-MAVLink implements two integrity checks: The first check is on the integrity of the packet during transmission using the X.25 checksum \([CRC-16-CCITT](https://en.wikipedia.org/wiki/Cyclic_redundancy_check)\). This however only ensures that the data has not been altered on the link - it does not ensure consistency with the data definition. The second integrity check is on the [data description](https://en.wikipedia.org/wiki/Data_definition_language) to ensure that two messages with the same ID are indeed containing the same information. To achieve this the data definition itself is run through CRC-16-CCITT and the resulting value is used to seed the packet CRC. Most reference implementations store this constant in an array named **CRC\_EXTRA**.
+MAVLink implements two integrity checks: The first check is on the integrity of the packet during transmission using the X.25 checksum ([CRC-16-CCITT](https://en.wikipedia.org/wiki/Cyclic_redundancy_check)). This however only ensures that the data has not been altered on the link - it does not ensure consistency with the data definition. The second integrity check is on the [data description](https://en.wikipedia.org/wiki/Data_definition_language) to ensure that two messages with the same ID are indeed containing the same information. To achieve this the data definition itself is run through CRC-16-CCITT and the resulting value is used to seed the packet CRC. Most reference implementations store this constant in an array named **CRC\_EXTRA**.
 

--- a/en/guide/mavlink_2.md
+++ b/en/guide/mavlink_2.md
@@ -1,18 +1,75 @@
 # MAVLink 2
 
 *MAVLink 2* is a backward-compatible update to the MAVLink protocol that has been designed to bring more flexibility and security to MAVLink communication.
+*MAVLink 2* bindings have been developed for C, C++11 and Python (see [Supported Languages](../README.md#supported_languages)).
+
+
+
+
+## Features
 
 The key new features of *MAVLink 2* are:
 * More than 256 message IDs (24 bit message ID - over 16 million packets)
-* [Packet signing](../guide/message_signing.md) (authentication)
-* [Extending existing MAVLink messages](#message_extensions)
-* [Empty-Byte packet truncation](#packet_truncation)
-* [Non-standard frame handling (Packet Compatibility Flags)](#framing)
+* Packet signing (authentication)
+* Extending existing MAVLink messages
+* Empty-byte payload truncation
+* Non-standard frame handling
 
-*MAVLink 2* bindings have been developed for C, C++11 and Python (see [Supported Languages](../README.md#supported_languages)).
+> **Tip** To better understand MAVLink 2, we recommend you start by reading the *MAVLink 2* [design document](https://docs.google.com/document/d/1XtbD0ORNkhZ8eKrsbSIZNLyg9sFRXMXbsR2mp37KbIg/edit?usp=sharing)
 
-> **Tip** We recommend you start by reading the *MAVLink 2* [design document](https://docs.google.com/document/d/1XtbD0ORNkhZ8eKrsbSIZNLyg9sFRXMXbsR2mp37KbIg/edit?usp=sharing)
 
+#### Message/Packet Signing
+
+Authentication is covered in the topic: [Message Signing](../guide/message_signing.md) (authentication)
+
+#### Empty-Byte Payload Truncation {#payload_truncation}
+
+MAVLink 2 truncates any empty (zero-filled) bytes at the end of the serialized payload before it is sent.
+This is more efficient that *MAVLink 1*, where bytes are sent for all fields - regardless of content.
+
+For more information see: [Serialization > Empty-Byte Payload Truncation](../guide/serialization.md#payload_truncation).
+
+
+#### Non-Standard Frame Handling {#framing}
+
+The MAVLink 2 [serialization format](../guide/serialization.md#mavlink2_packet_format) includes two new bitmap fields to indicate that a packet *supports* or *requires* some special/non-standard packet handling.
+
+The flags are primarily provided to allow for backwards compatible evolution of the protocol. 
+Older MAVLink implementations can process packets with compatible features, while rejecting packets with incompatible features.
+
+For more information see [Incompatibility flags](../guide/serialization.md#incompat_flags) and [Compatibility flags](../guide/serialization.md#compat_flags).
+
+
+#### Message Extensions {#message_extensions}
+
+MAVLink 2 defines "extension" fields, which can be added to an existing message without breaking binary compatibility for receivers that have not been updated.
+They can be used to extend any message, including those in the MAVLink 1 message id range.
+
+The rules for extensions messages are:
+
+* Extension fields are not sent when a message is encoded using the *MAVLink 1* protocol. 
+* If received by an implementation that doesn't have the extensions fields then the fields will not be seen.
+* If sent by an implementation that doesn't have the extensions fields then the recipient will see zero values for the extensions fields.
+* Extension fields are [not reordered](../guide/serialization.md#field_reordering) or included in the [CRC_EXTRA](../guide/serialization.md#crc_extra) when messages are serialized.
+
+For example the fields after the `<extensions>` line below are extension fields:
+
+```xml
+    <message id="100" name="OPTICAL_FLOW">
+      <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
+      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX)</field>
+      <field type="uint8_t" name="sensor_id">Sensor ID</field>
+      <field type="int16_t" name="flow_x" units="dpixels">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
+      <field type="int16_t" name="flow_y" units="dpixels">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
+      <field type="float" name="flow_comp_m_x" units="m">Flow in meters in x-sensor direction, angular-speed compensated</field>
+      <field type="float" name="flow_comp_m_y" units="m">Flow in meters in y-sensor direction, angular-speed compensated</field>
+      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
+      <field type="float" name="ground_distance" units="m">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
+      <extensions/>
+      <field type="float" name="flow_rate_x" units="rad/s">Flow rate in radians/second about X axis</field>
+      <field type="float" name="flow_rate_y" units="rad/s">Flow rate in radians/second about Y axis</field>
+    </message>
+```
 
 ## Upgrading an Existing C Installation
 
@@ -41,7 +98,6 @@ The major changes from an API perspective are:
 
 ### Sending and Receiving MAVLink 1 Packets
 
-
 The *MAVLink 2* library will send packets in *MAVLink 2* framing by default. 
 To force sending *MAVLink 1* packets on a particular channel you change the flags field of the status object. 
 
@@ -51,7 +107,6 @@ For example, the following code causes subsequent packets on the given channel t
 mavlink_status_t* chan_state = mavlink_get_channel_status(MAVLINK_COMM_0);
 chan_state->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
 ```
-
 
 Incoming *MAVLink 1* packets will be automatically handled as *MAVLink 1*. If you need to determine if a particular message was received as *MAVLink 1* or *MAVLink 2* then you can use the `magic` field of the message. In c programming, this is done like this:
 
@@ -79,84 +134,3 @@ if (mavlink_parse_char(MAVLINK_COMM_0, buf[i], &msg, &status)) {
 }
 ```
 
-
-## Message Extensions {#message_extensions}
-
-MAVLink 2 allows MAVLink 1 messages to be extended with *optional* fields.
-This allows for new fields to be added to a message without breaking binary compatibility for receivers that have not been updated.
-
-The rules for extensions messages are:
-
-* Extension fields are not sent when a message is encoded using the *MAVLink 1* protocol. 
-* If received by an implementation that doesn't have the extensions fields then the fields will not be seen.
-* If sent by an implementation that doesn't have the extensions fields then the recipient will see zero values for the extensions fields.
-* Extension fields are [not reordered](../guide/serialization.md#field_reordering) or included in the [CRC_EXTRA](../guide/serialization.md#crc_extra) when messages are serialized.
-
-For example the fields after the `<extensions>` line below are extension fields:
-
-```xml
-    <message id="100" name="OPTICAL_FLOW">
-      <description>Optical flow from a flow sensor (e.g. optical mouse sensor)</description>
-      <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX)</field>
-      <field type="uint8_t" name="sensor_id">Sensor ID</field>
-      <field type="int16_t" name="flow_x" units="dpixels">Flow in pixels * 10 in x-sensor direction (dezi-pixels)</field>
-      <field type="int16_t" name="flow_y" units="dpixels">Flow in pixels * 10 in y-sensor direction (dezi-pixels)</field>
-      <field type="float" name="flow_comp_m_x" units="m">Flow in meters in x-sensor direction, angular-speed compensated</field>
-      <field type="float" name="flow_comp_m_y" units="m">Flow in meters in y-sensor direction, angular-speed compensated</field>
-      <field type="uint8_t" name="quality">Optical flow quality / confidence. 0: bad, 255: maximum quality</field>
-      <field type="float" name="ground_distance" units="m">Ground distance in meters. Positive value: distance known. Negative value: Unknown distance</field>
-      <extensions/>
-      <field type="float" name="flow_rate_x" units="rad/s">Flow rate in radians/second about X axis</field>
-      <field type="float" name="flow_rate_y" units="rad/s">Flow rate in radians/second about Y axis</field>
-    </message>
-```
-
-
-## Message/Packet Signing
-
-Authentication is covered in the topic: [Message Signing](../guide/message_signing.md) (authentication)
-
-
-## Empty-Byte Packet Truncation {#packet_truncation}
-
-*MAVLink 2* truncates any empty (zero-filled) bytes at the end of the serialized message before it is sent.
-This contrasts with *MAVLink 1*, where bytes were sent for all fields regardless of content.
-
-The actual fields affected/bytes saved depends on the message and its content 
-(MAVLink [field reordering](../guide/serialization.md#field_reordering) means that all we can say is that any truncated fields will typically be those with the smallest data size, or extension fields).
-
-> **Note** The protocol only truncates empty bytes at the end of the serialized message; 
-  any null bytes/empty fields within the body of the message are not affected.
-
-
-## Packet Compatibility Flags {#framing}
-
-The [MAVLink 2 serialization format](../guide/serialization.md#mavlink2_packet_format) includes new bitmap fields (in C library: `incompat_flags` and `compat_flags`) to indicate that a packet supports or requires some special/non-standard packet handling.
-
-The flags are primarily provided to allow for backwards compatible evolution of the protocol. 
-Older MAVLink implementations can process packets with compatible features, while rejecting packets with incompatible features.
- 
-
-### Incompatibility Flags {#incompat_flags}
-
-Incompatibility flags are used to indicate features that a MAVLink library must support in order to be able to handle the packet.
-This includes any feature that affects the packet format/ordering.
-
-> **Note** A MAVLink implementation **must discard** a packet if it does not understand any flag in the `incompat_flags` field.
-
-Supported incompatibility flags include (at time of writing) :
-
-Flag | C flag | Feature 
---- | --- | ---
-<span id="MAVLINK_IFLAG_SIGNED"></span>0x01 | `MAVLINK_IFLAG_SIGNED` | The packet is [signed](../guide/message_signing.md) (a signature has been appended to the packet).
-
-
-### Compatibility Flags {#compat_flags}
-
-Compatibility flags are used to indicate features won't prevent a MAVLink library from handling the packet (even if the feature is not understood).
-This might include, for example, a flag to indicate that a packet should be treated as "high priority" 
-(such a messages could be handled by any MAVLink implementation because packet format and structure is not affected).
-
-A MAVLink implementation can safely ignore flags it doesn't understand in the `compat_flags` field.
-  
-  


### PR DESCRIPTION
This attempts to start moving away from a focus of "MAVLink 1 with MAVLink 2 additions" to find better places for some of the information. It is a bit experimental, but no worse in terms of content than previous version. May change in future. Self merging. 