### PR TITLE
Path Planning protocol docs

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -28,7 +28,7 @@
     * [File Transfer Protocol (FTP)](services/ftp.md)
     * [Landing Target Protocol](services/landing_target.md)
     * [Ping Protocol](services/ping.md)
-    * [Obstacle Avoidance](services/obstacle_avoidance.md)
+    * [Path Planning (Trajectory) Protocol](services/trajectory.md)
     obstacle_avoidance.md
   * [Message Signing](guide/message_signing.md)
   * [Serialization](guide/serialization.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -28,6 +28,8 @@
     * [File Transfer Protocol (FTP)](services/ftp.md)
     * [Landing Target Protocol](services/landing_target.md)
     * [Ping Protocol](services/ping.md)
+    * [Path Planning/Obstacle Avoidance](services/obstacle_avoidance.md)
+    obstacle_avoidance.md
   * [Message Signing](guide/message_signing.md)
   * [Serialization](guide/serialization.md)
   * [Routing](guide/routing.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -28,7 +28,7 @@
     * [File Transfer Protocol (FTP)](services/ftp.md)
     * [Landing Target Protocol](services/landing_target.md)
     * [Ping Protocol](services/ping.md)
-    * [Path Planning/Obstacle Avoidance](services/obstacle_avoidance.md)
+    * [Obstacle Avoidance](services/obstacle_avoidance.md)
     obstacle_avoidance.md
   * [Message Signing](guide/message_signing.md)
   * [Serialization](guide/serialization.md)

--- a/en/services/obstacle_avoidance.md
+++ b/en/services/obstacle_avoidance.md
@@ -1,0 +1,58 @@
+# Obstacle Avoidance Protocol
+
+This protocol allows an autopilot system to implement *obstacle avoidance* using an external system (e.g. a companion computer), enabling it to navigate around obstacles when following a preplanned path.
+
+## Overview
+
+A system that requires path planning services will send a message defining its current position and desired path.
+The external obstacle avoidance planning software determines if there is an obstacle, and if so sends back a stream of setpoints (in the same message type) that will navigate the vehicle around the obstacle.
+
+{% mermaid %}
+sequenceDiagram;
+    participant Autopilot
+    participant Companion
+    Autopilot->>Companion: Desired path/trajectory
+    Companion->>Companion: Calculate best trajectory
+    Companion-->>Autopilot: Target setpoint (if required)
+{% endmermaid %}
+
+Vehicles are expected to proceed to the last setpoint received and then proceed along their planned path.
+When there are no obstacles the path planning component should not send any setpoints.
+
+The protocol defines two messages, either of which may be used to represent the desired trajectory and/or target setpoint:
+* [TRAJECTORY_REPRESENTATION_WAYPOINTS](../messages/common.md#TRAJECTORY_REPRESENTATION_WAYPOINTS) - Trajectory represented as an array of up-to 5 *waypoints* in the *local frame*.
+* [TRAJECTORY_REPRESENTATION_BEZIER](../messages/common.md#TRAJECTORY_REPRESENTATION_BEZIER) - Trajectory represented using an array of up-to 5 bezier points in the local frame.
+
+> **Note** A particular system may support either or both representations for specifying both the target path and the received setpoint stream. 
+
+When specifying a desired path (using either message):
+- the first point (0th array index) always represents the current position/state of the vehicle.
+- Not all waypoints or curve points need necessarily be specified. 
+  - For waypoint messages typically only the current position, current waypoint and next waypoint are included. 
+  - Array indexes and values that are not used should be set as NaN. 
+
+When specifying a target setpoint, the values should be set in the first point of the message (0th array element).
+All other array fields should be set to NaN.
+
+The message sending update rate depends on the speed of the vehicle. <!-- 5Hz is OK for vehicle moving at ... ? -->
+
+
+## Implementations
+
+### PX4 Mission Mode
+
+The protocol has been implemented in PX4 to provide obstacle avoidance in *mission* mode: 
+- This uses `TRAJECTORY_REPRESENTATION_WAYPOINTS` messages only for both sending and receiving
+- Desired setpoint messages are sent at 5Hz 
+  - Index 0 is the vehicle current position, velocity and acceleration in the NED frame and vehicle yaw (`yaw_speed` is NaN)
+  - Index 1 and 2 are the current and next waypoints (position, yaw and yaw_speed setpoints are set, others are NaN)
+  - The other index values are not used (set to NaN).
+- Received setpoint messages arrive at 5Hz
+  - Index 0 is populated with the target position, velocity, yaw, and yaw_speed setpoints. 
+    The acceleration setpoint is set as NaN because it is not supported by PX4 firmware.
+  - All other index values are set to NaN.
+
+For more information see: TBD.
+
+
+<!-- * ? ArduPilot ? -->

--- a/en/services/trajectory.md
+++ b/en/services/trajectory.md
@@ -1,6 +1,6 @@
-# Path Planning (Trajectory) Protocol
+# Path Planning Protocol (Trajectory Interface)
 
-The path planning protocol (a.k.a. trajectory interface) is a general-purpose protocol for enabling dynamic path planning from an external system (e.g. a companion computer).
+The path planning protocol (a.k.a. trajectory interface) is a general-purpose protocol for a system to request dynamic path planning from another system (i.e. for an autopilot to request a path from a companion computer).
 
 The protocol is primarily intended for cases where constraints on the path to a destination are unknown or may change dynamically, but it can also be used for any other path management activities.
 Examples include: *obstacle avoidance* when following a preplanned mission, determining paths for self forming/healing swarms, offloading geofence management to a companion computer, etc.
@@ -8,8 +8,9 @@ Examples include: *obstacle avoidance* when following a preplanned mission, dete
 
 ## Overview
 
-The system that requires path-planning sends a message defining its current position and desired trajectory.
-The path planning software analyses the desired route and, if required (by the use case), sends back a stream of messages containing setpoints for a new path.
+The (autopilot) system that requires path-planning sends messages containing its current position and desired trajectory.
+The path planning system (companion computer) analyses the desired route, and sends back a stream of messages with setpoints for a new path.
+
 
 {% mermaid %}
 sequenceDiagram;
@@ -20,47 +21,37 @@ sequenceDiagram;
     Companion-->>Autopilot: Target setpoint (if required)
 {% endmermaid %}
 
-Vehicles are expected to move towards the most current setpoint from the remote system.
-If no new setpoints arrive before a vehicle reaches the last received setpoint, it may proceed along whatever path is currently demanded by the flight stack (e.g. a mission, return to land, etc.)
+When path planning is active, autopilots are expected to navigate using the most recent setpoint from the companion computer (and should have sensible behaviour if setpoints "run out").
 
-The protocol defines two messages, either of which may be used to represent the desired trajectory and/or target setpoint:
+> **Note** The path planning system might send setpoints all the time, or only when a desired trajectory cannot be achieved (this depends on the specific service implementation).
+
+The protocol defines two messages:
 * [TRAJECTORY_REPRESENTATION_WAYPOINTS](../messages/common.md#TRAJECTORY_REPRESENTATION_WAYPOINTS) - Trajectory represented as an array of up-to 5 *waypoints* in the *local frame*.
 * [TRAJECTORY_REPRESENTATION_BEZIER](../messages/common.md#TRAJECTORY_REPRESENTATION_BEZIER) - Trajectory represented using an array of up-to 5 bezier points in the local frame.
 
-> **Note** A particular system may support either or both representations for specifying both the target path and the received setpoint stream. 
+Either message may be used to represent both the desired trajectory and the target setpoint, and a system may support either or both messages.
 
 When specifying a desired path (using either message):
 - The first point (0th array index) always represents the current position/state of the vehicle.
-- Not all waypoints or curve points need necessarily be specified. 
-  - For waypoint messages typically only the current position, current waypoint and next waypoint are included. 
-  - Array indexes and values that are not used should be set as NaN. 
+  - For waypoint trajectories the current position usually needs either `position` or `velocity` fields, and either `yaw` or `yaw_speed` (not all of them)
+- It may not be necessary to specify a waypoint or curve point for every array index.
+  - For waypoint trajectories you might only need to specify points for the current position, current waypoint, and the next waypoint.
+- It may not be necessary to set a value for every field in a waypoint. 
+- Array indexes and field values that are not used should be set as NaN. 
 
 When specifying a target setpoint, the values should be set in the first point of the message (0th array element).
 All other array fields should be set to NaN.
 
-The message sending update rate depends on the speed of the vehicle and use case.
+The required message sending update rate depends on the speed of the vehicle and use case.
 
 
 ## Implementations
 
 ### Obstacle Avoidance in PX4 Mission Mode
 
-The protocol has been used to provide obstacle avoidance in PX4 missions mode.
-The path planning software (a ROS node) sends setpoints only when navigating the vehicle around obstacles.
-If there are no obstacles, the companion does not send setpoints, and the vehicle continues to execute the current mission.
+The protocol has been used to provide obstacle avoidance in PX4's mission mode.
+PX4 sends the current position, current waypoint, and next waypoint in a `TRAJECTORY_REPRESENTATION_WAYPOINTS` message (at 5Hz).
+The path planning software (a ROS node) sends setpoints for the duration of the mission. 
+These navigate the vehicle in a straight line to each waypoint, navigating around obstacles as needed.
 
-Note:
-- The implementation uses `TRAJECTORY_REPRESENTATION_WAYPOINTS` messages (only) for both sending and receiving.
-- Desired setpoint messages are sent at 5Hz.
-  - Index 0 is the vehicle current position, velocity and acceleration in the NED frame and vehicle yaw (`yaw_speed` is NaN)
-  - Index 1 and 2 are the current and next waypoints (position, yaw and yaw_speed setpoints are set, others are NaN)
-  - The other index values are not used (set to NaN).
-- Target setpoint messages are sent at 5Hz
-  - Index 0 is populated with the target position, velocity, yaw, and yaw_speed setpoints. 
-    The acceleration setpoint is set as NaN because it is not supported by PX4 firmware.
-  - All other index values are set to NaN.
-
-For more information see: TBD.
-
-
-<!-- * ? ArduPilot ? -->
+For more information see: [TBD](PX4GuideObstacleAvoidanceTopic).

--- a/en/services/trajectory.md
+++ b/en/services/trajectory.md
@@ -1,11 +1,15 @@
-# Obstacle Avoidance Protocol
+# Path Planning (Trajectory) Protocol
 
-This protocol allows an autopilot system to implement *obstacle avoidance* using an external system (e.g. a companion computer), enabling it to navigate around obstacles when following a preplanned path.
+The path planning protocol (a.k.a. trajectory interface) is a general-purpose protocol for enabling dynamic path planning from an external system (e.g. a companion computer).
+
+The protocol is primarily intended for cases where constraints on the path to a destination are unknown or may change dynamically, but it can also be used for any other path management activities.
+Examples include: *obstacle avoidance* when following a preplanned mission, determining paths for self forming/healing swarms, offloading geofence management to a companion computer, etc.
+
 
 ## Overview
 
-A system that requires path planning services will send a message defining its current position and desired path.
-The external obstacle avoidance planning software determines if there is an obstacle, and if so sends back a stream of setpoints (in the same message type) that will navigate the vehicle around the obstacle.
+The system that requires path-planning sends a message defining its current position and desired trajectory.
+The path planning software analyses the desired route and, if required (by the use case), sends back a stream of messages containing setpoints for a new path.
 
 {% mermaid %}
 sequenceDiagram;
@@ -16,8 +20,8 @@ sequenceDiagram;
     Companion-->>Autopilot: Target setpoint (if required)
 {% endmermaid %}
 
-Vehicles are expected to proceed to the last setpoint received and then proceed along their planned path.
-When there are no obstacles the path planning component should not send any setpoints.
+Vehicles are expected to move towards the most current setpoint from the remote system.
+If no new setpoints arrive before a vehicle reaches the last received setpoint, it may proceed along whatever path is currently demanded by the flight stack (e.g. a mission, return to land, etc.)
 
 The protocol defines two messages, either of which may be used to represent the desired trajectory and/or target setpoint:
 * [TRAJECTORY_REPRESENTATION_WAYPOINTS](../messages/common.md#TRAJECTORY_REPRESENTATION_WAYPOINTS) - Trajectory represented as an array of up-to 5 *waypoints* in the *local frame*.
@@ -26,7 +30,7 @@ The protocol defines two messages, either of which may be used to represent the 
 > **Note** A particular system may support either or both representations for specifying both the target path and the received setpoint stream. 
 
 When specifying a desired path (using either message):
-- the first point (0th array index) always represents the current position/state of the vehicle.
+- The first point (0th array index) always represents the current position/state of the vehicle.
 - Not all waypoints or curve points need necessarily be specified. 
   - For waypoint messages typically only the current position, current waypoint and next waypoint are included. 
   - Array indexes and values that are not used should be set as NaN. 
@@ -34,20 +38,24 @@ When specifying a desired path (using either message):
 When specifying a target setpoint, the values should be set in the first point of the message (0th array element).
 All other array fields should be set to NaN.
 
-The message sending update rate depends on the speed of the vehicle. <!-- 5Hz is OK for vehicle moving at ... ? -->
+The message sending update rate depends on the speed of the vehicle and use case.
 
 
 ## Implementations
 
-### PX4 Mission Mode
+### Obstacle Avoidance in PX4 Mission Mode
 
-The protocol has been implemented in PX4 to provide obstacle avoidance in *mission* mode: 
-- This uses `TRAJECTORY_REPRESENTATION_WAYPOINTS` messages only for both sending and receiving
-- Desired setpoint messages are sent at 5Hz 
+The protocol has been used to provide obstacle avoidance in PX4 missions mode.
+The path planning software (a ROS node) sends setpoints only when navigating the vehicle around obstacles.
+If there are no obstacles, the companion does not send setpoints, and the vehicle continues to execute the current mission.
+
+Note:
+- The implementation uses `TRAJECTORY_REPRESENTATION_WAYPOINTS` messages (only) for both sending and receiving.
+- Desired setpoint messages are sent at 5Hz.
   - Index 0 is the vehicle current position, velocity and acceleration in the NED frame and vehicle yaw (`yaw_speed` is NaN)
   - Index 1 and 2 are the current and next waypoints (position, yaw and yaw_speed setpoints are set, others are NaN)
   - The other index values are not used (set to NaN).
-- Received setpoint messages arrive at 5Hz
+- Target setpoint messages are sent at 5Hz
   - Index 0 is populated with the target position, velocity, yaw, and yaw_speed setpoints. 
     The acceleration setpoint is set as NaN because it is not supported by PX4 firmware.
   - All other index values are set to NaN.


### PR DESCRIPTION
This adds draft docs for the MAVLink protocol used for PX4 Obstacle avoidance. Rendered version can be seen [here](https://mavlink.io/v/obstacle_service/en/services/trajectory.html)

@mrivi Can you please review this and see comments inline. I'd like to start with the generic doc on protocol so I can link to it from PX4 information. 

> **NOTE** 7 Nov 2018 - This has been updated to be "generic" (not specific to obstacle avoidance)