### PR TITLE
[WIP] MAVLink tests - what do we have now?

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -59,4 +59,5 @@
   * [ualberta.xml](messages/ualberta.md)
   * [uAvionix.xml](messages/uAvionix.md)
 * [Contributing](contributing/contributing.md)
+  * [Testing](guide/testing.md)
 * [Support](about/support.md)

--- a/en/guide/testing.md
+++ b/en/guide/testing.md
@@ -1,0 +1,18 @@
+# Testing
+
+## Changes to Mavgen
+
+Changes to the mavgen generator (in [ArduPilot/pymavlink](https://github.com/ArduPilot/pymavlink)) are tested on every PR prior to acceptance into the master branch.
+
+You can run the test code yourself in Ubuntu.
+1. Install additional dependencies for gtest:
+   ```sh
+   sudo apt-get install cmake libgtest-dev
+   ```
+1. Run the test generator from the pymavlink directory:
+   ```sh
+   cd pymavlink
+   ./test_generator.sh
+   ```
+   > **Tip** The tests require message definitions in **../message_definitions/** (i.e. at the level above the **pymavlink** directory).
+     This is how things are set up when you're running the tests from the *mavlink* repo.


### PR DESCRIPTION
This is a *placeholder* for a topic we need about how to test MAVLink. Currently all it contains is information about how to run the Pymavlink tests for generated code locally on your computer. It does not explain what is actually tested other than "the generated libraries".
Minimally, before submission, this should also explain how users should test changes to message definitions by running the build with the XML validation turned on.

What I'd like to do is use this as a place to gather information about what the tests are, how they work, when they should be run, how they can be extended.