### PR TITLE
Range for MAV_CMD ids in common is 0 - 40000

### DIFF
--- a/en/guide/define_xml_element.md
+++ b/en/guide/define_xml_element.md
@@ -414,7 +414,7 @@ The allocated ranges are listed below.
 
 Dialect | Range
 --- | ---
-Common.xml | 30000 - 39999
+Common.xml | 0 - 39999
 asluav.xml | 40001 - 41999
 ArduPilotMega.xml | 42000 - 42999
 slugs.xml | 10001 - 11999


### PR DESCRIPTION
Not 30000 as currently indicated.