### PR TITLE
MavgenC: Not include headers of included dialects

### DIFF
--- a/en/mavgen_c/README.md
+++ b/en/mavgen_c/README.md
@@ -39,7 +39,7 @@ To use MAVLink in your C project, include the **mavlink.h** header file for your
 ```
 This will automatically add the header files for all messages in your dialect, and for any dialect files that it includes.
 
-If you support multiple *independent* dialects you can include these separately (there is no need to separately include dialects that are part of another dialect, but this will do no harm):
+If you support multiple *independent* dialects you can include these separately.
 
 ```c
 #include <common/mavlink.h>
@@ -47,6 +47,10 @@ If you support multiple *independent* dialects you can include these separately 
 #include <another_dialect/mavlink.h>
 ```
 
+> **Warning** Avoid including header files of *dependent* dialects (those included by your dialect). 
+  If you include the headers in the wrong order the enums/messages of the parent dialect may not be available to your code.
+
+<span></span>
 > **Tip** *Do not include the individual message files*. 
   If you generate your own headers, you will have to add their output location to your C compiler's search path. 
 


### PR DESCRIPTION
Added clear advice that you should only include your top level dialect(s), but not header files generated for sub dialects.

The reason is that C only allows enums to be defined once - not extended. So the top level #defines all sub dialect enums/message ids. If you include in the wrong order you will lose the parent dialect definitions.