### PR TITLE
ParameterProtocol: Describe param cache mechanism

### DIFF
--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -182,7 +182,7 @@ The drone may restart the sequence the `PARAM_VALUE` acknowledgment is not recei
 PX4 implements the protocol in a way that is compatible with this specification.
 
 PX4 additionally provides a mechanism that allows a GCS to *cache* parameters, which significantly reduces ready-to-use time for the GCS if parameters have not been changed since the previous parameter sync.
-The way that this mechanism works is that when the list of parameters is requested, PX4 first sends a parameter value with the `param_index` of `INT16_MAX` (in code, referred to as `PARAM_HASH`) containing a *hash* of the parameter set. 
+The way that this mechanism works is that when the list of parameters is requested, PX4 first sends a `PARAM_VALUE` with the `param_index` of `INT16_MAX` (in code, referred to as `PARAM_HASH`) containing a *hash* of the parameter set. 
 If the GCS has a matching hash value it can immediately start using its cached parameters (rather than waiting for all of them to upload).
 
 Source files:

--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -183,7 +183,7 @@ PX4 implements the protocol in a way that is compatible with this specification.
 
 PX4 additionally provides a mechanism that allows a GCS to *cache* parameters, which significantly reduces ready-to-use time for the GCS if parameters have not been changed since the previous parameter sync.
 The way that this mechanism works is that when the list of parameters is requested, PX4 first sends a `PARAM_VALUE` with the `param_index` of `INT16_MAX` (in code, referred to as `PARAM_HASH`) containing a *hash* of the parameter set. 
-If the GCS has a matching hash value it can immediately start using its cached parameters (rather than waiting for all of them to upload).
+If the GCS has a matching hash value it can immediately start using its cached parameters (instead of waiting for all of the rest to upload).
 
 Source files:
 * [src/modules/mavlink/mavlink_parameters.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_parameters.cpp)

--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -181,6 +181,10 @@ The drone may restart the sequence the `PARAM_VALUE` acknowledgment is not recei
 
 PX4 implements the protocol in a way that is compatible with this specification.
 
+PX4 additionally provides a mechanism that allows a GCS to *cache* parameters, which significantly reduces ready-to-use time for the GCS if parameters have not been changed since the previous parameter sync.
+The way that this mechanism works is that when the list of parameters is requested, PX4 first sends a parameter value with the `param_index` of `INT16_MAX` (in code, referred to as `PARAM_HASH`) containing a *hash* of the parameter set. 
+If the GCS has a matching hash value it can immediately start using its cached parameters (rather than waiting for all of them to upload).
+
 Source files:
 * [src/modules/mavlink/mavlink_parameters.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_parameters.cpp)
 * [src/modules/mavlink/mavlink_parameters.h](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_parameters.h)

--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -183,7 +183,8 @@ PX4 implements the protocol in a way that is compatible with this specification.
 
 PX4 additionally provides a mechanism that allows a GCS to *cache* parameters, which significantly reduces ready-to-use time for the GCS if parameters have not been changed since the previous parameter sync.
 The way that this mechanism works is that when the list of parameters is requested, PX4 first sends a `PARAM_VALUE` with the `param_index` of `INT16_MAX` (in code, referred to as `PARAM_HASH`) containing a *hash* of the parameter set. 
-If the GCS has a matching hash value it can immediately start using its cached parameters (instead of waiting for all of the rest to upload).
+This hash is calculated by computing the CRC32 over all param names and values (see the `param_hash_check()` in source [here](https://github.com/PX4/Firmware/blob/v1.9.0-alpha/src/lib/parameters/parameters.cpp#L1329)). 
+If the GCS has a matching hash value it can immediately start using its cached parameters (rather than having to wait while all the rest of the parameters upload).
 
 Source files:
 * [src/modules/mavlink/mavlink_parameters.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_parameters.cpp)


### PR DESCRIPTION
This describes my interpretation of the code around GCS parameter caching. 
Essentially the first item sent on request for the list of parameters is the hash of all parameters with a special index. The GCS gets this index, compares the hash, and if it is the same can start using the cached set of parameters without having to wait. If it is not the same the GCS can collect the remaining parameters as usual. 

Notes:
- I think this is not part of the "official" protocol which is why it is under the PX4 Implementation section (correct me if I'm wrong).
- it would be more efficient if the remaining parameters were not send if the hash matched, but the protocol has no mechanism for stopping the rest being sent. Please confirm what I wrote is accurate.


