### PR TITLE
[WIP] MissionService: Structure doc. Add ArduPilot/PX4 deltas from spec

### DIFF
--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -5,7 +5,7 @@ The mission sub-protocol allows a GCS or developer API to manage *mission* (flig
 The protocol covers:
 - Operations to upload, download and clear missions, set/get the current mission item number, and get notification when the current mission item has changed.
 - Message type(s) for exchanging mission items.
-- MAVLink commands that are common to most autpilots/GCS.
+- MAVLink commands that are common to most autopilots/GCS.
 
 The protocol follows the client/server pattern, where operations (and most commands) are initiated by the GCS/developer API (client) and acknowledged by the autopilot (server).
 
@@ -27,8 +27,7 @@ The mission type is specified in a MAVLink 2 message extension field: `mission_t
 The protocol uses the same sequence of operations for all types (albeit with different MAVLink commands).
 
 
-
-## MAVLink Commands {#mavlink_commands}
+## Mission Items/MAVLink Commands {#mavlink_commands}
 
 MAVLink commands are defined in the [MAV_CMD](../messages/common.md#MAV_CMD) enum.
 
@@ -63,12 +62,41 @@ Field Name | Type | Values | Description
 --- | --- | --- | ---
 target_system | uint8_t | | System ID
 target_component | uint8_t | | Component ID
-seq | uint16_t |  | Sequence number for 
+seq | uint16_t |  | Sequence number for message.
 frame | uint8_t | MAV_FRAME | The coordinate system of the waypoint.<br>ArduPilot and PX4 both only support global frames in MAVLink commands (local frames may be supported if the same command is sent via the command protocol).
 mission_type | uint8_t | MAV_MISSION_TYPE | [Mission type](#mission_types).
 current | uint8_t | false:0, true:1 | When downloading, whether the item is the current mission item.
 autocontinue | uint8_t | | Autocontinue to next waypoint when the command completes.
 
+
+## Message/Enum Summary
+
+The following messages and enums are used by the service.
+
+Message | Description
+-- | --
+<span id="MISSION_REQUEST_LIST"></span>[MISSION_REQUEST_LIST](../messages/common.md#MISSION_REQUEST_LIST) | Initiate [mission download](#download_mission) from a system by requesting the list of mission items.
+<span id="MISSION_COUNT"></span>[MISSION_COUNT](../messages/common.md#MISSION_COUNT) | Send the number of items in a mission. This is used to initiate [mission upload](#uploading_mission) or as a response to [MISSION_REQUEST_LIST](#MISSION_REQUEST_LIST) when [downloading a mission].
+<span id="MISSION_REQUEST_INT"></span>[MISSION_REQUEST_INT](../messages/common.md#MISSION_REQUEST_INT) | Request mission item data for a specific sequence number be sent by the recipient using a [MISSION_ITEM_INT](#MISSION_ITEM_INT) message. Used for mission [upload](#uploading_mission) and [download](#download_mission).
+<span id="MISSION_REQUEST"></span>[MISSION_REQUEST](../messages/common.md#MISSION_REQUEST) | Request mission item data for a specific sequence number be sent by the recipient using a [MISSION_ITEM](#MISSION_ITEM) message. Used for mission [upload](#uploading_mission) and [download](#download_mission).
+<span id="MISSION_ITEM_INT"></span>[MISSION_ITEM_INT](../messages/common.md#MISSION_ITEM_INT) | Message encoding a [mission item/command](#mavlink_commands) (defined in a [MAV_CMD](#MAV_CMD)). The message encodes positional information in integer parameters for greater precision than [MISSION_ITEM](#MISSION_ITEM). Used for mission [upload](#uploading_mission) and [download].
+<span id="MISSION_ITEM"></span>[MISSION_ITEM](../messages/common.md#MISSION_ITEM) | Message encoding a [mission item/command](#mavlink_commands) (defined in a [MAV_CMD](#MAV_CMD)). The message encodes positional information in `float` parameters. Used for mission [upload](#uploading_mission) and [download](#download_mission).
+<span id="MISSION_ACK"></span>[MISSION_ACK](../messages/common.md#MISSION_ACK) | Acknowledgment message when a system completes a [mission operation](#operations) (e.g. sent by autopilot after it has uploaded all mission items). The message includes a [MAV_MISSION_RESULT](#MAV_MISSION_RESULT) indicating either success or the type of failure.
+<span id="MISSION_CURRENT"></span>[MISSION_CURRENT](../messages/common.md#MISSION_CURRENT) | Message containing the current mission item sequence number. This is emitted when the [current mission item is set/changed](#current_mission_item).
+<span id="MISSION_SET_CURRENT"></span>[MISSION_SET_CURRENT](../messages/common.md#MISSION_SET_CURRENT) | [Set the current mission item](#current_mission_item) by sequence number (continue to this item on the shortest path).
+<span id="STATUSTEXT"></span>[STATUSTEXT](../messages/common.md#STATUSTEXT) | Sent to notify systems when a request to [set the current mission item](#current_mission_item) fails.
+<span id="MISSION_CLEAR_ALL"></span>[MISSION_CLEAR_ALL](../messages/common.md#MISSION_CLEAR_ALL) | Message sent to [clear/delete all mission items](#clear_mission) stored on a system.
+<span id="MISSION_ITEM_REACHED"></span>[MISSION_ITEM_REACHED](../messages/common.md#MISSION_ITEM_REACHED) | Message emitted by system whenever it reaches a new waypoint. Used to [monitor progress](#monitor_progress).
+<span id="MISSION_REQUEST_PARTIAL_LIST"></span>[MISSION_REQUEST_PARTIAL_LIST](../messages/common.md#MISSION_REQUEST_PARTIAL_LIST) | TBD.
+<span id="MISSION_WRITE_PARTIAL_LIST"></span>[MISSION_WRITE_PARTIAL_LIST](../messages/common.md#MISSION_WRITE_PARTIAL_LIST) | TBD.
+
+
+Enum | Description
+-- | --
+<span id="MAV_MISSION_TYPE"></span>[MAV_MISSION_TYPE](../messages/common.md#MAV_MISSION_TYPE) | [Mission type](#mission_types) for message (mission, geofence, rallypoints).
+<span id="MAV_MISSION_RESULT"></span>[MAV_MISSION_RESULT](../messages/common.md#MAV_MISSION_RESULT) | Used to indicate the success or failure reason for an operation (e.g. to upload or download a mission). This is carried in a [MISSION_ACK](#MISSION_ACK).
+<span id="MAV_FRAME"></span>[MAV_FRAME](../messages/common.md#MAV_FRAME) | Co-ordinate frame for position/velocity/acceleration data in the message.
+<span id="MAV_CMD"></span>[MAV_CMD](../messages/common.md#MAV_CMD) | [Mission Items](#mavlink_commands) (and MAVLink commands). These can be sent in [MISSION_ITEM](#MISSION_ITEM) or [MISSION_ITEM_INT](#MISSION_ITEM_INT).
 
 
 ## Operations {#operations}
@@ -95,21 +123,13 @@ sequenceDiagram;
     Drone->>GCS: MISSION_ACK
 {% endmermaid %}
 
-
-Note:
-- The GCS (client) sets a [timeout](#timeout) after every message and will resend if there is no response from the vehicle.
-- The client will re-request mission items that are received out of sequence.
-- The sequence above shows the [MAVLink commands](#mavlink_commands) packaged in [MISSION_ITEM_INT](../messages/common.md#MISSION_ITEM_INT) messages. 
-  Protocol implementations must also support [MISSION_ITEM](../messages/common.md#MISSION_ITEM) and [MISSION_REQUEST](../messages/common.md#MISSION_REQUEST) in the same way (see [MISSION_ITEM_INT vs MISSION_ITEM below](#command_message_type)).
-
-
 In more detail, the sequence of operations is:
 1. GCS (client) sends [MISSION_COUNT](../messages/common.md#MISSION_COUNT) including the number of mission items to be uploaded (`count`)
    - A [timeout](#timeout) must be started for the GCS to wait on the response from Drone (`MISSION_REQUEST_INT`) .
 1. Drone (server) receives the message, and prepares to upload mission items.
-1. Drone responds with [MISSION_REQUEST_INT](../messages/common.md#MISSION_REQUEST_INT) requesting the mission number to upload (`seq`)
+1. Drone responds with [MISSION_REQUEST_INT](../messages/common.md#MISSION_REQUEST_INT) requesting the first mission item (`seq==1`).
 1. GCS receives `MISSION_REQUEST_INT` and responds with the requested mission item in a [MISSION_ITEM_INT](../messages/common.md#MISSION_ITEM_INT) message.
-1. Drone and GCS repeat the `MISSION_REQUEST_INT`/`MISSION_ITEM_INT` cycle until all items are uploaded.
+1. Drone and GCS repeat the `MISSION_REQUEST_INT`/`MISSION_ITEM_INT` cycle, iterating `seq` until all items are uploaded.
 1. For the last mission item, the drone responds with [MISSION_ACK](../messages/common.md#MISSION_ACK) with the result of the operation result: `type` ([MAV_MISSION_RESULT](../messages/common.md#MAV_MISSION_RESULT)):
    - On success, `type` must be set to [MAV_MISSION_ACCEPTED](../messages/common.md#MAV_MISSION_ACCEPTED)
    - On failure, `type` must set to [MAV_MISSION_ERROR](../messages/common.md#MAV_MISSION_ERROR) or some other error code. 
@@ -117,9 +137,13 @@ In more detail, the sequence of operations is:
    - If `MAV_MISSION_ACCEPTED` the operation is complete.
    - If an error, the transaction fails but may be retried. <!-- not clear here -->
 
+Note:
+- The GCS (client) sets a [timeout](#timeout) after every message and will resend if there is no response from the vehicle.
+- The client will re-request missing mission items if any are received out of sequence.
+- The sequence above shows the [MAVLink commands](#mavlink_commands) packaged in [MISSION_ITEM_INT](../messages/common.md#MISSION_ITEM_INT) messages. 
+  Protocol implementations must also support [MISSION_ITEM](../messages/common.md#MISSION_ITEM) and [MISSION_REQUEST](../messages/common.md#MISSION_REQUEST) in the same way (see [MISSION_ITEM_INT vs MISSION_ITEM below](#command_message_type)).
 
-
-### Download a Mission from the Vehicle
+### Download a Mission from the Vehicle {#download_mission}
 
 The diagram below shows the communication sequence to download a mission from a drone (assuming all operations succeed).
 
@@ -139,12 +163,11 @@ sequenceDiagram;
     GCS->>Drone: MISSION_ACK
 {% endmermaid %}
 
+The sequence is similar to that for [uploading a mission](#uploading_mission).
+The main difference is that the client (e.g. GCS) sends [MISSION_REQUEST_LIST](../messages/common.md#MISSION_REQUEST_LIST), which triggers the autopilot to respond with the current count of items. This starts a cycle where the GCS requests mission items, and the drone supplies them.
 
 > **Note** The sequence shows the [MAVLink commands](#mavlink_commands) packaged in [MISSION_ITEM_INT](../messages/common.md#MISSION_ITEM_INT) messages. 
   Protocol implementations must also support [MISSION_ITEM](../messages/common.md#MISSION_ITEM) and [MISSION_REQUEST](../messages/common.md#MISSION_REQUEST) in the same way (see [MISSION_ITEM_INT vs MISSION_ITEM below](#command_message_type)).
-
-The sequence is similar to that for [uploading a mission](#uploading_mission).
-The main difference is that the client (e.g. GCS) sends [MISSION_REQUEST_LIST](../messages/common.md#MISSION_REQUEST_LIST), which triggers the autopilot to respond with the current count of items. This starts a cycle where the GCS requests mission items, and the drone supplies them.
 
 
 ### Set Current Mission Item {#current_mission_item}
@@ -159,22 +182,18 @@ sequenceDiagram;
     Drone-->>GCS: MISSION_CURRENT
 {% endmermaid %}
 
-Notes:
-* There is no specific timeout/resend on this message.
-* The acknowledgment of the message is via broadcast of mission/system status, which is not associated with the original message.
-  This approach is used because the message is relevant to all mission-handling clients.
-
-
 In more detail, the sequence of operations is:
 1. GCS (client) sends [MISSION_SET_CURRENT](../messages/common.md#MISSION_SET_CURRENT), specifying the new sequence number (`seq`). 
 1. Drone (server) receives message and attempts to update the current mission sequence number.
    - On success, the Drone should *broadcast* a [MISSION_CURRENT](../messages/common.md#MISSION_CURRENT) message containing the current sequence number (`seq`). 
    - On failure, the Drone should *broadcast* a [STATUSTEXT](../messages/common.md#STATUSTEXT) with a [MAV_SEVERITY](../messages/common.md#MAV_SEVERITY) and a string stating the problem. This may be displayed in the UI of receiving systems.
-   
 
+Notes:
+* There is no specific timeout/resend on this message.
+* The acknowledgment of the message is via broadcast of mission/system status, which is not associated with the original message.
+  This approach is used because the message is relevant to all mission-handling clients.
 
-
-### Monitor Mission Progress
+### Monitor Mission Progress {#monitor_progress}
 
 GCS/developer API can monitor progress by handling the appropriate messages sent by the drone:
 - The vehicle (server) must broadcast a [MISSION_ITEM_REACHED](../messages/common.md#MISSION_ITEM_REACHED) message whenever a new mission item is reached.
@@ -182,7 +201,7 @@ The message contains the `seq` number of the current mission item.
 - The vehicle must  also broadcast a [MISSION_CURRENT](../messages/common.md#MISSION_CURRENT) message if the [current mission item](#current_mission_item) is changed by a message.
 
 
-### Clear Missions
+### Clear Missions {#clear_mission}
 
 The diagram below shows the communication sequence to clear the mission from a drone (timeouts are not displayed, and we assume all operations succeed).
 
@@ -237,17 +256,51 @@ The only difference is that `MISSION_ITEM_INT` encodes the latitude and longitud
 The *defacto* standard file format for exchanging missions/plans is discussed in: [File Formats > Mission Plain-Text File Format](../file_formats/README.md#mission_plain_text_file).
 
 
-## C Implementation
+## Implementations
 
-The protocol has been implemented in C by PX4 <!-- and ArduPilot Flight Stacks, --> and *QGroundControl*.  
-This implementation can be used in your own code within the terms of their software licenses.
+<!-- detail below is approximate - still checking precise behaviour vs spec -->
 
-PX4 Implementation:
+### PX4
+
+The protocol has been implemented in C.
+
+Mission upload, download, clearing missions, and monitoring progress are supported a defined in this specification.
+
+Partial mission upload and download are not supported (e.g. [MISSION_REQUEST_PARTIAL_LIST](#MISSION_REQUEST_PARTIAL_LIST) and[MISSION_WRITE_PARTIAL_LIST](#MISSION_WRITE_PARTIAL_LIST)).
+
+Source code:
 * [src/modules/mavlink/mavlink_mission.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_mission.cpp)
 
-QGroundControl* implementation:
+
+### QGroundControl
+
+The protocol has been implemented in C.
+
+Source code:
 * [src/MissionManager/PlanManager.cc](https://github.com/mavlink/qgroundcontrol/blob/master/src/MissionManager/PlanManager.cc)
 
-ArduPilot
-* TBD
+### ArduPilot
 
+The protocol has been implemented in C.
+
+Mission upload, download, clearing missions, and monitoring progress and partial mission upload ([MISSION_WRITE_PARTIAL_LIST](#MISSION_WRITE_PARTIAL_LIST)) are supported.
+Partial mission download is not supported ([MISSION_REQUEST_PARTIAL_LIST](#MISSION_REQUEST_PARTIAL_LIST)).
+
+ArduPilot's implementation differs from this specification (non-exhaustively):
+- The mission sequence number (`seq` in commands) is indexed from 0 instead of 1.
+  The zero index is populated with the home position of the vehicle.
+  Index 1 and later are the mission items, as per the specification.
+
+<!-- Other possible differences include: 
+- may emit wrong type of info on partial write for fail case, 
+- may not do robust update. Checking
+- may not support cancellation of upload.
+-->
+
+### Dronecode SDK
+
+TBD
+
+### DroneKit
+
+TBD

--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -228,10 +228,12 @@ In more detail, the sequence of operations is:
 1. If no `MISSION_ACK` is received the operation will eventually timeout and may be retried (see [above](#timeout)).
 
 
+
+
 ### Timeouts and Retries {#timeout}
 
 All the client (GCS) commands are sent with a timeout.
-If a `MISSION_ACK` is not received before the timeout then the client (GCS) may resend the message. <!-- really guaranteed? What about partial-states in vehicle -->
+If a `MISSION_ACK` is not received before the timeout then the client (GCS) may resend the message.
 If no response is received after a number of retries then the client must cancel the operation and return to an idle state.
 
 The recommended timeout values before resending, and the number of retries are:


### PR DESCRIPTION
Improve document structure. Capture deltas for ArduPilot implementation. 

WIP while I make docs "more complete". Need to cover:
- ArduPilot differences
- Atomic/robust updates
- Partial uploads/reads