### PR TITLE
MissionProtocol: Partial upload/download

### DIFF
--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -364,12 +364,9 @@ Note:
 
 ### Canceling Operations {#cancel}
 
-The above mission operations can be canceled by responding to any request (e.g. `MISSION_REQUEST_INT`) with a `MISSION_ACK` message containing `MAV_MISSION_DENIED` (or another error).
-Both systems should then return themselves to the idle state (if the receiving system does not receive the cancellation message it will resend and get another error response).
-<!-- note, 
-- we need a proper enum value for cancellation as may end up with wrong status messages https://github.com/mavlink/mavlink/pull/1044
-- ardupilot doesn't support cancellation. 
--->
+The above mission operations may be canceled by responding to any request (e.g. `MISSION_REQUEST_INT`) with a `MISSION_ACK` message containing the `MAV_MISSION_OPERATION_CANCELLED` error.
+
+Both systems should then return themselves to the idle state (if the system does not receive the cancellation message it will resend the request; the recipient will then be in the idle state and may respond with an appropriate error for that state).
 
 
 ### Operation Exceptions

--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -362,6 +362,16 @@ Note:
   Protocol implementations must also support [MISSION_ITEM](../messages/common.md#MISSION_ITEM) and [MISSION_REQUEST](../messages/common.md#MISSION_REQUEST) in the same way.
 
 
+### Canceling Operations {#cancel}
+
+The above mission operations can be canceled by responding to any request (e.g. `MISSION_REQUEST_INT`) with a `MISSION_ACK` message containing `MAV_MISSION_DENIED` (or another error).
+Both systems should then return themselves to the idle state (if the receiving system does not receive the cancellation message it will resend and get another error response).
+<!-- note, 
+- we need a proper enum value for cancellation as may end up with wrong status messages https://github.com/mavlink/mavlink/pull/1044
+- ardupilot doesn't support cancellation. 
+-->
+
+
 ### Operation Exceptions
 
 #### Timeouts and Retries {#timeout}
@@ -377,7 +387,6 @@ The recommended timeout values before resending, and the number of retries are:
 
 
 #### Errors/Completion {#errors}
-
 
 All operations complete with a [MISSION_ACK](../messages/common.md#MISSION_ACK) message containing the result of the operation ([MAV_MISSION_RESULT](../messages/common.md#MAV_MISSION_RESULT)) in the `type` field.
 
@@ -417,6 +426,13 @@ The implementation status is (at time of writing):
 - Geofence missions" are supported as defined in this specification.
 - Rally point "missions" are not supported on PX4.
 
+Mission operation cancellation works for mission download (sets system to idle).
+Mission operation cancellation does not work for mission uploading; PX4 resends `MISSION_REQUEST_INT` until the operation times out. 
+<!-- https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_mission.cpp#L641 -->
+
+Source code:
+* [src/modules/mavlink/mavlink_mission.cpp](https://github.com/PX4/Firmware/blob/master/src/modules/mavlink/mavlink_mission.cpp)
+
 
 ### QGroundControl
 
@@ -431,7 +447,7 @@ Source code:
 ArduPilot implements the mission protocol in C++.
 
 ArduPilot uses the same messages and message flow described in this specification. 
-There are some implementation diferences that affect compatibility.
+There are some implementation differences that affect compatibility.
 These are documented below.
 
 Source:

--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -163,6 +163,7 @@ Note:
   For example, the drone might respond to the [MISSION_COUNT](../messages/common.md#MISSION_COUNT) request with a [MAV_MISSION_NO_SPACE](../messages/common.md#MAV_MISSION_NO_SPACE) if there isn't enough space to upload the mission.
 - The sequence above shows the [mission items](#mavlink_commands) packaged in [MISSION_ITEM_INT](../messages/common.md#MISSION_ITEM_INT) messages. 
   Protocol implementations must also support [MISSION_ITEM](../messages/common.md#MISSION_ITEM) and [MISSION_REQUEST](../messages/common.md#MISSION_REQUEST) in the same way.
+- Uploading an empty mission ([MISSION_COUNT](../messages/common.md#MISSION_COUNT) is 0) has the same effect as [clearing the mission](#clear_mission).
 
 
 ### Download a Mission from the Vehicle {#download_mission}

--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -272,9 +272,8 @@ The mission update must either overlap or immediately follow the final mission i
 > **Note** The message sequence similar to a [full mission upload](#uploading_mission), except that it is triggered with a [MISSION_WRITE_PARTIAL_LIST](../messages/common.md#MISSION_WRITE_PARTIAL_LIST) instead of a [MISSION_COUNT](../messages/common.md#MISSION_COUNT).
 
 <span></span>
-> **Note** Unlike for full mission update, partial update is not required to be robust.
-  - Individual commands can fail, and a mission may be left partially updated.
-  - It is the responsibility of the mission planning software to ensure that, if successful, the new mission is self-consistent (i.e. the autopilot is not expected to validate that updates are "sane" with respect to other/existing items in the mission).
+> **Note** As for full mission update, partial update is required to be robust.
+  The upload must succeed or fail completely, leaving the uploader in no doubt of the current mission state.
 
 {% mermaid %}
 sequenceDiagram;


### PR DESCRIPTION
This updates the sections for partial upload/download of missions. PX4 does not implement this so what I have done is inferred sensible operation from the normal upload/download and reviewed ArduPilot implementation. 

Would be good if I can get some confirmation that the proposal is sensible even though it might not perfectly match what ArduPilot does @WickedShell, @auturgy . Rendered version is here: https://hamishwillee.gitbooks.io/ham_mavdevguide/content/v/mission_ap/en/services/mission.html#upload_partial

What I have said is 
1. Partial upload is JUST LIKE full upload except it is triggered by `MISSION_WRITE_PARTIAL_LIST` instead of a `MISSION_COUNT`
   - I have stated that this has to be robust like a full update (ie update succeeds completely or fails and original state restored). Is this OK?  [NOTE, ArduPilot just overwrites the existing item]
1. Partial download does not have a clear mapping to full download.
   - After MISSION_REQUEST_PARTIAL_LIST is sent there is no obvious ACK to tell GCS that it should now request items (for full download drone  returns MISSION_COUNT).
   - What I think happens is that after MISSION_REQUEST_PARTIAL_LIST is sent the GCS just starts requesting mission items. The drone can be set up to always return any particular item on request with out any problem. Is that reasonable?