### PR TITLE
[WIP] MissionProtocol:ArduPilot compatibility

### DIFF
--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -341,6 +341,8 @@ ArduPilot's implementation differs from this specification (non-exhaustively):
   As long as ArduPilot has not yet timed-out a system can retry the current mission item upload. 
 - A mission cannot be cleared while it is being executed (i.e. while in Auto mode). 
   Note that a new mission *can* be uploaded (even a zero-size mission - which is equivalent to clearing).
+- Explicit cancellation of operations is not supported.
+  If one end stops communicating the other end will eventually timeout and reset itself to an idle/ready state.
 
 
 The following behaviour is not defined by the specification (but is still of interest):


### PR DESCRIPTION
This adds an ArduPilot compatibility section 
- makes it clear how ArduPilot differs from the spec
- tries to make it clear how ArduPilot behaves irrespective of the spec in order to work out where the spec might be deficient (ie we should specify more).
- At the end someone implementing a GCS or API to talk to ArduPilot should be able to get this to work from the docs.