### PR TITLE
Clarify use MAVLink2 and Release process

### DIFF
--- a/en/about/faq.md
+++ b/en/about/faq.md
@@ -19,6 +19,24 @@
   <dt>How secure is MAVLink?</dt>
   <dd>MAVLink provides <a href="../guide/message_signing.md">message signing</a>, which allows systems to authenticate that messages are from a trusted source. MAVLink does not provide message encryption.  
   </dd>
+  
+  <dt>What version of MAVLink should I use?</dt>
+  <dd>You should use the <a href="../guide/mavlink_2.md">MAVLink 2</a> protocol where at all possible (it fixes a number of limitations of earlier versions). 
+  The <em>MAVLink 2</em> libraries also support <em>MAVLink 1</em>, so you can use them to communicate with legacy systems if needed. 
+  </dd>
+  
+ <dt>How often is MAVLink updated/released?</dt>
+  <dd>
+
+
+  <ul>
+    <li>The underlying over-the-wire format is rarely updated (we're only up to <em>MAVLink 2</em>, which was introduced in 2017).
+    </li>
+    <li>New <a href="../messages/common.md">messages</a>/<a href="../services/README.md">microservices</a> are frequently added. This is a backwards compatible change, and users are expected to regularly update their libraries to support new messages.</li>
+    <li>Messages are rarely modified (or removed) such that they would become incompatible. If this is needed the project will update the MAVLink minor version number and notify users through the <a href="https://groups.google.com/forum/#!forum/mavlink">mailing list</a> (users can also query the version in code).</li>
+  </ul>
+  </dd>
+  
 </dl>
 
 


### PR DESCRIPTION
Added this as attempt to answer slack query "what is your release process". My understanding of the process is that we try to only make changes that are backward compatible so that we don't have to do any sort of official notifications to avoid "breaking" people.
What this says though is that we can do it if we want, but we'll email the mailing list to notify. 
@auturgy seem reasonable?

Also added direct suggestion to use MAVLink 2 over MAVLink 2 - seems like a good idea!