### PR TITLE
Add info about param attributes

### DIFF
--- a/en/guide/define_xml_element.md
+++ b/en/guide/define_xml_element.md
@@ -491,3 +491,20 @@ To declare a param as `reserved` with `default` value of `0` simply omit the `pa
 
 If you have just one unused `param` we recommend you simply don't declare it. 
 If you have more than one, you may wish to explicitly define it with default of `NaN` so that you can extend your command later with ether default. 
+
+
+#### GUI Param Attributes
+
+A number of [param](../guide/xml_schema.md#param) attributes are provided as "GUI hints". 
+
+These attributes are used to better display params:
+- `label` - Label for param in GCS/UI.
+  All words in label should be capitalised (e.g. "Hold Altitude").
+- `units` - SI units for the value.
+- `decimalPlaces` - Hint to a UI about how many decimal places to use if the parameter value is displayed.
+
+These attributes help a GCS customise the editing experience (e.g. controls can choose to only offer allowed values).
+- `enum` - Enum containing possible values for the parameter (if applicable).
+- `increment` - Allowed increments for the parameter value.
+- `minValue` - Minimum value for param.
+- `maxValue` - Maximum value for the param.

--- a/en/guide/xml_schema.md
+++ b/en/guide/xml_schema.md
@@ -142,7 +142,8 @@ A `param` **should** have:
 - `description`: Parameter description string (tag body)
 
 A `param` **should** also include the following optional attributes where appropriate (which may be used by a GUI for parameter display and editing):
-- `label` - Display name to represent the parameter in a GCS or other UI
+- `label` - Display name to represent the parameter in a GCS or other UI. 
+  All words in label should be capitalised.
 - `units` - SI units for the value.
 - `enum` - Enum containing possible values for the parameter (if applicable).
 - `decimalPlaces` - Hint to a UI about how many decimal places to use if the parameter value is displayed.


### PR DESCRIPTION
Primarily adding this to clarify that all words in a param label should be capitalised.