### PR TITLE
Locally unprocessable messages should be treated as broadcast

### DIFF
--- a/en/guide/routing.md
+++ b/en/guide/routing.md
@@ -28,8 +28,7 @@ Addressed messages are resent on a new channel *iff* the system has previously s
 > **Warning** Forwarded messages must not be changed/repackaged by the forwarding system (the original message is passed to the new link).
 
 <span></span>
-> **Note** Systems should treat messages that they cannot process as broadcast messages, and forward appropriately (e.g. if the message is not supported/understood by the library, or if they don't have the correct signature for authenticating a message).
-
+> **Note** Systems should treat messages that they cannot read as broadcast messages, and forward appropriately (i.e. for messages that are not supported/understood by the library). Signed messages that cannot be authenticated (but which can be read) should be forwarded according to the normal routing rules.
 
 ## Routing Detail
 

--- a/en/guide/routing.md
+++ b/en/guide/routing.md
@@ -28,7 +28,7 @@ Addressed messages are resent on a new channel *iff* the system has previously s
 > **Warning** Forwarded messages must not be changed/repackaged by the forwarding system (the original message is passed to the new link).
 
 <span></span>
-> **Note** Systems should treat messages that they cannot read as broadcast messages, and forward appropriately (i.e. for messages that are not supported/understood by the library). Signed messages that cannot be authenticated (but which can be read) should be forwarded according to the normal routing rules.
+> **Note** Systems should, where possible, forward messages according to the routing rules *even if they are unable to process them* (e.g. signed messages that cannot be authenticated). Messages that are not supported/understood by the library should be forwarded as though they were broadcast messages (in this case the target system/component ids cannot be read).
 
 ## Routing Detail
 

--- a/en/guide/routing.md
+++ b/en/guide/routing.md
@@ -28,7 +28,8 @@ Addressed messages are resent on a new channel *iff* the system has previously s
 > **Warning** Forwarded messages must not be changed/repackaged by the forwarding system (the original message is passed to the new link).
 
 <span></span>
-> **Note** Systems must forward messages according to the routing rules *even if they are unable to process them* (e.g. if using a library that does not include the message, or if they don't have the correct signature for authenticating a message).
+> **Note** Systems should treat messages that they cannot process as broadcast messages, and forward appropriately (e.g. if the message is not supported/understood by the library, or if they don't have the correct signature for authenticating a message).
+
 
 ## Routing Detail
 


### PR DESCRIPTION
FYI @olliw42 This clarifies that if a message cannot be handled locally it should be treated as a broadcast message and forwarded appropriately. 

The previous text said that it should be forwarded according to the routing rules. The subtle difference is that if the message is not understood then the system _cannot_ determine the target component/system id. So forwarding according to the intention of the message is not possible. 