### PR TITLE
Clarify what libs can be generated by mavgen

### DIFF
--- a/en/getting_started/generate_libraries.md
+++ b/en/getting_started/generate_libraries.md
@@ -2,9 +2,13 @@
 
 Language-specific MAVLink libraries can be created from [XML Message Definitions](../messages/README.md) using *code generator* tools.
 
-The available code generators and supported output languages for each version of the MAVLink protocol are listed in [Supported Languages](../README.md#supported_languages) (these include C, C#, Java, Python etc).
+This topic shows how to use the two code generators provided with the MAVLink project: [mavgenerate](#mavgenerate) (GUI) and [mavgen](#mavgen) (command line).
 
-This topic shows how to use the two code generators provided with the MAVLink project: [mavgenerate](#mavgenerate) (GUI) and [mavgen](#mavgen) (command line) (other code generators are documented by their associated projects).
+> **Note** These generators can build MAVLink 2 libraries for C, C++11, Python, Java, and WLua (supporting both MAVLink 2 and 1), and MAVLink 1 (only) libraries for: CS, JavaScript, ObjC, Swift.
+
+<span></span>
+> **Tip** Generators for other programming languages are supported and documented in independent progects.
+  For more information see [Supported Languages](../README.md#supported_languages).
 
 
 ## Pre-requisites


### PR DESCRIPTION
Fixes #178

The previous version implied that the supported languages table defined what libraries can be _generated_ by mavgen, when actually it documents what versions of the protocol are supported for each programming language. 

This was confusing because the supported languages says C++11 supports MAVLink 1 (which it does, via the MAVLink 2 library) and a user was interpreting this to mean that the generator can create a MAVLink 1-only  library.

The fix explicitly states what libraries can be generated by mavgen, and links to the table only for other programming languages.