### PR TITLE
Update docs to indicate CS has mavlink 2 support

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -45,7 +45,7 @@ Language | Generator | MAVLink v1 | MAVLink v2 | Signing | Notes
 C       | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | Y | Y | This is the MAVLink project reference implementation. [Generated libraries](#prebuilt_libraries) are also published for both protocol versions.
 C++11   | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | Y | Y | 
 Python (2.7+, 3.3+) | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | Y | Y | 
-C#      | [mavgen](getting_started/generate_libraries.md#mavgen) | Y |  | 
+C#      | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | Y | Y |
 Objective C | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | | | 
 Java    | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | | |
 Java    | [dronefleet/mavlink](https://github.com/dronefleet/mavlink) | Y | Y | Y | *Idiomatic* Java SDK/API for MAVLink. Provides a gradle plugin for the code generator.

--- a/en/getting_started/generate_libraries.md
+++ b/en/getting_started/generate_libraries.md
@@ -4,7 +4,7 @@ Language-specific MAVLink libraries can be created from [XML Message Definitions
 
 This topic shows how to use the two code generators provided with the MAVLink project: [mavgenerate](#mavgenerate) (GUI) and [mavgen](#mavgen) (command line).
 
-> **Note** These generators can build MAVLink 2 libraries for C, C++11, Python, Java, and WLua (supporting both MAVLink 2 and 1), and MAVLink 1 (only) libraries for: CS, JavaScript, ObjC, Swift.
+> **Note** These generators can build MAVLink 2 libraries for C, C++11, C#, Python, Java, and WLua (supporting both MAVLink 2 and 1), and MAVLink 1 (only) libraries for: JavaScript, ObjC, Swift.
 
 <span></span>
 > **Tip** Generators for other programming languages are supported and documented in independent progects.


### PR DESCRIPTION
At time of writing there are build errors reported when you run generator. These will be fixed in https://github.com/ArduPilot/pymavlink/pull/318 - but they don't prevent usage of ouputs.