### PR TITLE
Add Go library

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -53,6 +53,7 @@ JavaScript | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | | |
 Lua     | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | Y | | 
 Swift   | [mavgen](getting_started/generate_libraries.md#mavgen) | Y | | | 
 Clojure | [clj-mavlink](https://github.com/WickedShell/clj-mavlink) | Y | Y | Y | Clojure MAVLink Bindings.
+Go      | [gomavlib](https://github.com/gswly/gomavlib) | Y | Y | Y | |
 
 
 


### PR DESCRIPTION
In the past months i've developed a pure-Go Mavlink library (https://github.com/gswly/gomavlib), that is finally stable enough to be used in production systems.

In particular, the library:
* is part of the software of a rover used during maintenance of state-owned Italian dams and underground power lines
* supports transparently Mavlink 1.0, 2.0 and all the 2.0 features (zero byte truncation, signing, extra fields)
* is written in standard, clear Go (https://goreportcard.com/report/github.com/gswly/gomavlib)
* ships with a huge test suite and CI (https://travis-ci.org/gswly/gomavlib)
* has a complete and standard documentation (https://godoc.org/github.com/gswly/gomavlib)
* has examples (https://github.com/gswly/gomavlib/tree/master/example)
* has a very permissive license (MIT)

Since:
* Go is one of the fastest rising programming languages of the last years
* all the other Mavlink Go libraries are in the development phase or lack some features

i propose to add the library to the Mavlink documentation.
