### PR TITLE
Param protocol: PARAM_REQUEST_LIST timeout and zero params

### DIFF
--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -133,7 +133,7 @@ The sequence of operations is:
    - The GCS determines what parameters are missing for each component based on the `param_count` and `param_index` fields from received [PARAM_VALUE](../messages/common.md#PARAM_VALUE) messages.
    - The messages are [requested individually](#read_single) using [PARAM_REQUEST_READ](../messages/common.md#PARAM_REQUEST_READ) and the missing `param_index`.
    - A timeout is set on each request.
-     A GCS should fail gracefully on timeout and is expected to reporting errors for incomplete parameter reads.
+     A GCS should fail gracefully on timeout.
    
 
 ### Read Single Parameter {#read_single}

--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -81,11 +81,12 @@ All components must respond to parameter request messages addressed to their ID 
 
 The protocol is designed with the assumption that the parameter set does not change during normal operation.
 
-If a system can add parameters during (or after) initial sychronisation the protocol cannot guarantee reliable/robust syncronisation, because there is no way to notify that the parameter set has changed and a new sync is required.
+If a system can add parameters during (or after) initial synchronization the protocol cannot guarantee reliable/robust synchronization, because there is no way to notify that the parameter set has changed and a new sync is required.
 
 When requesting parameters from such a system, the risk of problems can be *reduced* (but not removed) if:
 * The `param_id` is used to read parameters where possible (the mapping of `param_index` to a particular parameter may change on systems where parameters can be added/removed).
-* [PARAM_VALUE](../messages/common.md#PARAM_VALUE).`param_count` may be monitored. If this changes the parameter set should be re-sychronised.
+* [PARAM_VALUE](../messages/common.md#PARAM_VALUE).`param_count` may be monitored.
+  If this changes the parameter set should be re-sychronised.
 
 ## Parameter Operations
 
@@ -99,8 +100,8 @@ A GCS will usually read all parameters when first connecting to a system, in ord
 > **Note** The Drone will emit a [PARAM_VALUE](../messages/common.md#PARAM_VALUE) whenever a parameter is [written/changed](#write).
   Provided the GCS keeps track of changed parameters, it should not need to re-read the full parameter list.
 
-Reading the parameter list is activated by sending the [PARAM_REQUEST_LIST](../messages/common.md#PARAM_REQUEST_LIST) message. 
-The target component should start to broadcast the parameters individually in `PARAM_VALUE` messages after receiving this message. 
+Reading the parameter list is activated by sending the [PARAM_REQUEST_LIST](../messages/common.md#PARAM_REQUEST_LIST) message.
+The target component should start to broadcast the parameters individually in `PARAM_VALUE` messages after receiving this message.
 The drone should allow a pause after sending each parameter to ensure that the operation doesn't consume all of the available link bandwidth (30 - 50 percent of the bandwidth is reasonable).
 
 {% mermaid %}
@@ -111,30 +112,35 @@ sequenceDiagram;
     GCS-->>GCS: Start receive timeout (any params)
     Drone->>GCS: Send N parameters with PARAM_VALUE
     GCS-->>GCS: Start receive timeout (after each param)
-    Note over GCS: Timeout (drone sent all params)
-    GCS->>Drone: Request each missing param by index (PARAM_REQUEST_READ)
-    GCS-->>GCS: Start receive timeout
-    Drone->>GCS: Send param with PARAM_VALUE
+    Note over GCS: Finish/timeout when no more params received
 {% endmermaid %}
 
 The sequence of operations is:
 
 1. GCS (client) sends [PARAM_REQUEST_LIST](../messages/common.md#PARAM_REQUEST_READ) specifying a target system/component.
-   - Broadcast addresses may be used. All targetted components should respond with parameters (or ignore the request if they have none).
+   - Broadcast addresses may be used.
+     All targeted components should respond with parameters (or ignore the request if they have none).
    - The GCS is expected to accumulate parameters from all responding systems.
-   - GCS starts a timeout timer and waits for parameters.
-     On timeout the GCS should fail gracefully (reset the state machine).
-1. The targetted component(s) should respond, sending all parameters individually in [PARAM_VALUE](../messages/common.md#PARAM_VALUE) messages.
+   - The timeout/retry behaviour is GSC dependent.
+1. The targeted component(s) should respond, sending all parameters individually in [PARAM_VALUE](../messages/common.md#PARAM_VALUE) messages.
    - Allow breaks between each message in order to avoid saturating the link.
    - Components with no parameters should ignore the request.
-1. GCS accumulates parameters for each compent in order to know which parameters have been/not been received (`PARAM_VALUE` contains total number of params and index of current param).
-1. GCS starts timeout after each `PARAM_VALUE` message in order to detect when parameters are no longer being sent.
-1. After timeout (All components finished sending params) the GCS individually requests any missing parameter values.
-   - The GCS determines what parameters are missing for each component based on the `param_count` and `param_index` fields from received [PARAM_VALUE](../messages/common.md#PARAM_VALUE) messages.
-   - The messages are [requested individually](#read_single) using [PARAM_REQUEST_READ](../messages/common.md#PARAM_REQUEST_READ) and the missing `param_index`.
-   - A timeout is set on each request.
-     A GCS should fail gracefully on timeout.
-   
+1. GCS starts timeout after each `PARAM_VALUE` message in order to detect when parameters are no longer being sent (that the operation has completed).
+
+Handling of missing params is GCS-dependent.
+
+The GCS/API accumulates received parameters for each component and can determine if any are missing/not received (`PARAM_VALUE` contains total number of params and index of current param).
+*QGroundControl*, for example, [individually requests](#read_single) each missing parameter by index, using [PARAM_REQUEST_READ](../messages/common.md#PARAM_REQUEST_READ) as shown below:
+
+{% mermaid %}
+sequenceDiagram;
+    participant GCS
+    participant Drone
+    GCS->>Drone: Req. missing params by index (PARAM_REQUEST_READ)
+    GCS-->>GCS: Start receive timeout
+    Drone->>GCS: Send param with PARAM_VALUE
+{% endmermaid %}
+
 
 ### Read Single Parameter {#read_single}
 

--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -111,7 +111,8 @@ sequenceDiagram;
     GCS-->>GCS: Start receive timeout (any params)
     Drone->>GCS: Send N parameters with PARAM_VALUE
     GCS-->>GCS: Start receive timeout (after each param)
-    GCS->>Drone: Request individual missing param by index (PARAM_REQUEST_READ)
+    Note over GCS: Timeout (drone sent all params)
+    GCS->>Drone: Request each missing param by index (PARAM_REQUEST_READ)
     GCS-->>GCS: Start receive timeout
     Drone->>GCS: Send param with PARAM_VALUE
 {% endmermaid %}
@@ -128,10 +129,11 @@ The sequence of operations is:
    - Components with no parameters should ignore the request.
 1. GCS accumulates parameters for each compent in order to know which parameters have been/not been received (`PARAM_VALUE` contains total number of params and index of current param).
 1. GCS starts timeout after each `PARAM_VALUE` message in order to detect when parameters are no longer being sent.
-1. After timeout (params no longer being received) the GCS individually requests any missing parameter values.
-
-   The GCS determines what parameters are missing for each component based on the `param_count` and `param_index` fields from received [PARAM_VALUE](../messages/common.md#PARAM_VALUE) messages.
-   The messages are [requested individually](#read_single) using [PARAM_REQUEST_READ](../messages/common.md#PARAM_REQUEST_READ) and the missing `param_index`.
+1. After timeout (All components finished sending params) the GCS individually requests any missing parameter values.
+   - The GCS determines what parameters are missing for each component based on the `param_count` and `param_index` fields from received [PARAM_VALUE](../messages/common.md#PARAM_VALUE) messages.
+   - The messages are [requested individually](#read_single) using [PARAM_REQUEST_READ](../messages/common.md#PARAM_REQUEST_READ) and the missing `param_index`.
+   - A timeout is set on each request.
+     A GCS should fail gracefully on timeout and is expected to reporting errors for incomplete parameter reads.
    
 
 ### Read Single Parameter {#read_single}

--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -127,10 +127,10 @@ The sequence of operations is:
    - Components with no parameters should ignore the request.
 1. GCS starts timeout after each `PARAM_VALUE` message in order to detect when parameters are no longer being sent (that the operation has completed).
 
-Handling of missing params is GCS-dependent.
+The GCS/API accumulates received parameters for each component and can determine if any are missing/not received (`PARAM_VALUE` contains total number of params and index of current param). 
 
-The GCS/API accumulates received parameters for each component and can determine if any are missing/not received (`PARAM_VALUE` contains total number of params and index of current param).
-*QGroundControl*, for example, [individually requests](#read_single) each missing parameter by index, using [PARAM_REQUEST_READ](../messages/common.md#PARAM_REQUEST_READ) as shown below:
+**Handling of missing params is GCS-dependent.**
+*QGroundControl*, for example, [individually requests](#read_single) each missing parameter by index (using [PARAM_REQUEST_READ](../messages/common.md#PARAM_REQUEST_READ) as shown below):
 
 {% mermaid %}
 sequenceDiagram;


### PR DESCRIPTION
Fixes https://github.com/mavlink/mavlink/issues/1139 . 

Specifically it clarifies that:
- GCS should timeout on non-response to PARAM_REQUEST_LIST
- All addressed components should respond with parameters if they have them, and otherwise ignore the request. 
- This therefore explains what components should do if they have no params.

@DonLakeFlyer Note that this is slightly more generic than what QGC does. You specifically notify the user if the autopilot does not respond with params. I don't comment on that - as long as the recipient does not send params if it doesn't have any and the GCS times out, it can notify or not for any component as it likes. 

@DonLakeFlyer @olliw42 - WOuld appreciate your sanity check. You can preview this here: https://hamishwillee.gitbooks.io/ham_mavdevguide/content/v/zero_params/en/services/parameter.html#read_all

