### PR TITLE
FTP: Add File/Folder not found NAK

### DIFF
--- a/en/services/ftp.md
+++ b/en/services/ftp.md
@@ -106,13 +106,13 @@ Error | Name | Description
 <span id="Fail"></span>1                | Fail            | Unknown failure
 <span id="FailErrno"></span>2           | FailErrno       | Command failed, Err number sent back in `PayloadHeader.data[1]`. This is a file-system error number understood by the server operating system.
 <span id="InvalidDataSize"></span>3     | InvalidDataSize | Payload `size` is invalid
-<span id="InvalidSession"></span>4      | InvalidSessionn | Session is not currently open
+<span id="InvalidSession"></span>4      | InvalidSession  | Session is not currently open
 <span id="NoSessionsAvailable"></span>5 | NoSessionsAvailable | All available sessions are already in use.
 <span id="EOF"></span>6                 | EOF             | Offset past end of file for `ListDirectory` and `ReadFile` commands.
 <span id="UnknownCommand"></span>7      | UnknownCommand  | Unknown command / opcode
 <span id="FileExists"></span>8          | FileExists      | File already exists
 <span id="FileProtected"></span>9       | FileProtected   | File is write protected
-
+<span id="NotFound"></span>10           | NotFound        | File/folder not found
 
 
 ## Timeouts/Resending {#timeouts}

--- a/en/services/ftp.md
+++ b/en/services/ftp.md
@@ -112,7 +112,7 @@ Error | Name | Description
 <span id="UnknownCommand"></span>7      | UnknownCommand  | Unknown command / opcode
 <span id="FileExists"></span>8          | FileExists      | File/directory already exists
 <span id="FileProtected"></span>9       | FileProtected   | File/directory is write protected
-<span id="NotFound"></span>10           | FileNotFound    | File/directory not found
+<span id="FileNotFound"></span>10       | FileNotFound    | File/directory not found
 
 
 ## Timeouts/Resending {#timeouts}

--- a/en/services/ftp.md
+++ b/en/services/ftp.md
@@ -110,9 +110,9 @@ Error | Name | Description
 <span id="NoSessionsAvailable"></span>5 | NoSessionsAvailable | All available sessions are already in use.
 <span id="EOF"></span>6                 | EOF             | Offset past end of file for `ListDirectory` and `ReadFile` commands.
 <span id="UnknownCommand"></span>7      | UnknownCommand  | Unknown command / opcode
-<span id="FileExists"></span>8          | FileExists      | File already exists
-<span id="FileProtected"></span>9       | FileProtected   | File is write protected
-<span id="NotFound"></span>10           | NotFound        | File/folder not found
+<span id="FileExists"></span>8          | FileExists      | File/directory already exists
+<span id="FileProtected"></span>9       | FileProtected   | File/directory is write protected
+<span id="NotFound"></span>10           | FileNotFound    | File/directory not found
 
 
 ## Timeouts/Resending {#timeouts}


### PR DESCRIPTION
Fixes https://github.com/mavlink/mavlink/issues/1209

Note, I just made error "NotFound" so it can cover both Files and Folders (Dirs). HOw do people feel about naming? FileFolderNotFound, ErrorNotFound, PathNotFound are all options