### PR TITLE
serialization: clarify empty-byte truncation in case of empty payloads

### DIFF
--- a/en/guide/serialization.md
+++ b/en/guide/serialization.md
@@ -167,6 +167,8 @@ This contrasts with *MAVLink 1*, where bytes were sent for all fields regardless
 The actual fields affected/bytes saved depends on the message and its content 
 (MAVLink [field reordering](../guide/serialization.md#field_reordering) means that all we can say is that any truncated fields will typically be those with the smallest data size, or extension fields).
 
+> **Note** The first byte of the payload is never truncated, even if the payload consists entirely of zeros.
+
 > **Note** The protocol only truncates empty bytes at the end of the serialized message payload; 
   any null bytes/empty fields within the body of the payload are not affected.
 


### PR DESCRIPTION
Hi, recently i stumbled upon an incompatibility issue between libraries, related to the empty-byte truncation feature:
https://github.com/gswly/gomavlib/pull/2

* gomavlib was built by following the developer guide, which says to truncate all empty-bytes at the end of a payload, even if the payload becomes null
* the reference c library implements the empty-byte feature in a different way, as it always keeps at least a byte in the payload

A change in the c library is not possible, as it would influence all the Mavlink ecosystem; instead, i propose to add this behavior to the documentation, in order to clarify the situation.
