### PR TITLE
Add smart battery service docs

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -57,5 +57,6 @@
   * [Landing Target Protocol](services/landing_target.md)
   * [Ping Protocol](services/ping.md)
   * [Path Planning (Trajectory) Protocol](services/trajectory.md)
+  * [Smart Battery Protocol (WIP)](services/smart_battery.md)
 * [Contributing](contributing/contributing.md)
 * [Support](about/support.md)

--- a/en/services/README.md
+++ b/en/services/README.md
@@ -24,3 +24,4 @@ The main microservices are shown in the sidebar (most are listed below):
 * [Landing Target Protocol](../services/landing_target.md)
 * [Ping Protocol](../services/ping.md)
 * [Path Planning Protocol](../services/trajectory.md) (Trajectory Interface) 
+* [Smart Battery Protocol](../services/smart_battery.md)

--- a/en/services/smart_battery.md
+++ b/en/services/smart_battery.md
@@ -1,0 +1,25 @@
+# Smart Battery Protocol (WIP)
+
+> **Note** The Smart Battery messages are tagged in the definition file as "work in progress".
+  They may still change and should not be used in production environments.
+
+The Smart Battery "protocol" consists of two broadcast messages:
+- [SMART_BATTERY_INFO](#SMART_BATTERY_INFO) contains information about the battery that changes rarely, if ever (e.g. device name).
+  It should be emitted on connection and/or when requested (using [MAV_CMD_REQUEST_MESSAGE](../messages/common.md#MAV_CMD_REQUEST_MESSAGE)).
+- [SMART_BATTERY_STATUS](#SMART_BATTERY_STATUS) contains battery status information that changes frequently (it is equivalent to [BATTERY_STATUS](../messages/common.md#BATTERY_STATUS) for smart batteries).
+  It should be emitted regularly - e.g.: 0.5Hz.
+  
+The messages may be sent from a smart battery to the flight stack and/or GCS.
+It is also possible that a flight stack may re-emit smart battery information after updating some fields.
+
+
+## Message/Enum Summary
+
+Message | Description
+-- | --
+<span id="SMART_BATTERY_INFO"></span>[SMART_BATTERY_INFO](../messages/common.md#SMART_BATTERY_INFO) |  Smart battery message used for invariant or infrequently changing data - e.g. battery name, battery full/empty capacity and voltages etc.
+<span id="SMART_BATTERY_STATUS"></span>[SMART_BATTERY_STATUS](../messages/common.md#SMART_BATTERY_STATUS) | Smart battery message used for frequent status update - e.g. of current capacity, voltages, faults, etc.
+
+Enum | Description
+-- | --
+<span id="MAV_SMART_BATTERY_FAULT"></span>[MAV_SMART_BATTERY_FAULT](../messages/common.md#MAV_SMART_BATTERY_FAULT) | Fault/health indications.


### PR DESCRIPTION
This is minimal docs for the smart battery "service". I'm aware this is not a protocol in the same way as most of the others, ie. in that it has no message sequence etc. It is however useful to group the messages.

@julianoes I'm hoping the services protocol you're reviewing for this weeks mavlink meeting can do this in a more automated way - ie for a basic grouping of messages in a service we can just document this at the top level of a message definition and automatically build this kind of doc if we want. 