### PR TITLE
Parameters: Clarify read invalid param

### DIFF
--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -175,6 +175,10 @@ The sequence of operations is:
 
 The drone may restart the sequence if the `PARAM_VALUE` acknowledgment is not received within the timeout.
 
+> **Note** There is no formal way for the drone to signal when an invalid parameter is requested (i.e. for a parameter name or id that does not exist).
+  In this case the drone *should* emit [STATUS_TEXT](../messages/common.md#STATUS_TEXT).
+  The GCS may monitor for the specific notification, but will otherwise fail the request after any timeout/resend cycle completes. 
+
 ### Write Parameters {#write}
 
 Parameters can be written individually by sending the parameter name and value pair to the GCS, as shown:


### PR DESCRIPTION
Fixes https://github.com/mavlink/mavlink-devguide/issues/186

So in normal flow GCS first reads all params, after which it has a list of params, a range of ids and a list of ids that it has names for. From the range and ids the GCS has, it knows what ids are missing, so it can request these params individually by id.

The protocol assumes that you can always read a param value by name - ie [that they are invariant](https://mavlink.io/en/services/parameter.html#parameters-assumed-invariant). It also assumes thatd that the ids are can be relied upon at least for the time while you are doing your initial reads.

However neither of these things are necessarily true. 

What this does is explain what happens if you try read a param that is not defined by name or ID. Essentially this is not properly supported - PX4 emits a status_text and QGC displays it. All this PR does is make it clear what you might choose to do outside of the protocol. 