### PR TITLE
Camera battery status publishing

### DIFF
--- a/en/services/camera.md
+++ b/en/services/camera.md
@@ -227,6 +227,12 @@ The steps are:
 
 > **Note** If your camera only provides video streaming and nothing else (no camera features), the [CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM](../messages/common.md#CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM) flag is the only flag you need to set. 
   The GCS will then provide video streaming support and skip camera control.
+  
+### Battery Status
+
+Cameras that are powered from their own battery should publish [BATTERY_STATUS](../messages/common.md#BATTERY_STATUS) messages.
+`BATTERY_STATUS.battery_function` should be set to [MAV_BATTERY_TYPE_PAYLOAD](../messages/common.md#MAV_BATTERY_TYPE_PAYLOAD).
+
 
 ## Message/Enum Summary
 

--- a/en/services/camera.md
+++ b/en/services/camera.md
@@ -231,7 +231,8 @@ The steps are:
 ### Battery Status
 
 Camera components that are powered from their own battery should publish [BATTERY_STATUS](../messages/common.md#BATTERY_STATUS) messages.
-`BATTERY_STATUS.battery_function` should be set to [MAV_BATTERY_TYPE_PAYLOAD](../messages/common.md#MAV_BATTERY_TYPE_PAYLOAD).
+
+Other components like a GCS will typically only use the camera `BATTERY_STATUS.battery_remaining` field (or possibly `time_remaining`); generally other fields can be set as "not supported".
 
 
 ## Message/Enum Summary

--- a/en/services/camera.md
+++ b/en/services/camera.md
@@ -230,7 +230,7 @@ The steps are:
   
 ### Battery Status
 
-Cameras that are powered from their own battery should publish [BATTERY_STATUS](../messages/common.md#BATTERY_STATUS) messages.
+Camera components that are powered from their own battery should publish [BATTERY_STATUS](../messages/common.md#BATTERY_STATUS) messages.
 `BATTERY_STATUS.battery_function` should be set to [MAV_BATTERY_TYPE_PAYLOAD](../messages/common.md#MAV_BATTERY_TYPE_PAYLOAD).
 
 


### PR DESCRIPTION
Follows on from https://github.com/mavlink/qgroundcontrol/pull/7964

@dogmaphobic @olliw42 I don't think we should say more than this in the MAVLink spec. The QGC developer guide might additionally say what the camera widget does with such information.

Reasonable?