### PR TITLE
mavlink_system must be declared in global scope

### DIFF
--- a/en/mavgen_c/README.md
+++ b/en/mavgen_c/README.md
@@ -52,6 +52,15 @@ When compiling the project, we recommend that you specify the top-level output d
 $ gcc ... -I generated/include -I generated/include/common ...
 ```
 
+In order to *send messages* you will also need to declare a variable `mavlink_system` in the **global scope**, specifying the system id and component ID of your component:
+```cpp
+mavlink_system_t mavlink_system = {
+	1, //Sytem ID (1-255)
+	1  //Component ID 
+}; 
+```
+
+
 ## Multiple Streams ("channels") {#channels}
 
 The C MAVLink library utilizes a "channel" metaphor to allow for simultaneous processing of multiple, independent MAVLink streams in the same program.

--- a/en/mavgen_c/README.md
+++ b/en/mavgen_c/README.md
@@ -55,8 +55,8 @@ $ gcc ... -I generated/include -I generated/include/common ...
 In order to *send messages* you will also need to declare a variable `mavlink_system` in the **global scope**, specifying the system id and component ID of your component:
 ```cpp
 mavlink_system_t mavlink_system = {
-	1, //Sytem ID (1-255)
-	1  //Component ID 
+	1, // System ID (1-255)
+	1  // Component ID (MAV_COMPONENT)
 }; 
 ```
 

--- a/en/mavgen_c/README.md
+++ b/en/mavgen_c/README.md
@@ -56,7 +56,7 @@ In order to *send messages* you will also need to declare a variable `mavlink_sy
 ```cpp
 mavlink_system_t mavlink_system = {
 	1, // System ID (1-255)
-	1  // Component ID (MAV_COMPONENT)
+	1  // Component ID (a MAV_COMPONENT value)
 }; 
 ```
 


### PR DESCRIPTION
Fixes https://github.com/mavlink/mavlink/issues/1330

Well, technically it just documents the dependency. We should fix the headers, but that's a bigger problem.

@peterbarker - seem reasonable?