### PR TITLE
camera_def: add note about CAM_MODE param

### DIFF
--- a/en/services/camera_def.md
+++ b/en/services/camera_def.md
@@ -36,6 +36,8 @@ An extended set of parameter messages is used to define settings and options. Th
 
 Parameters can be simple or quite complex, depending on the behavior they change.
 
+> **Note** The parameter CAM_MODE needs to part of the parameter list. It maps to the command [MAV_CMD_SET_CAMERA_MODE](../messages/common.md#MAV_CMD_SET_CAMERA_MODE). It allows to expose different settings based on the mode, so photo settings in photo mode and video settings in video mode.
+
 #### Parameter Types
 
 The type of the parameter follows the enum [MAV_PARAM_EXT_TYPE](../messages/common.md#MAV_PARAM_EXT_TYPE_UINT8). Within the XML file, these are defined as:

--- a/en/services/camera_def.md
+++ b/en/services/camera_def.md
@@ -32,11 +32,15 @@ All fields are self explanatory:
 
 ### Parameters
 
-An extended set of parameter messages is used to define settings and options. These minimally have a parameter name, type and default value (types can be predefined or arbitrary - though arbitrary types are only supported by custom camera controllers). They will also have a description that is displayed to the user and the set of possible options. 
+An extended set of parameter messages is used to define settings and options.
+These minimally have a parameter name, type and default value (types can be predefined or arbitrary - though arbitrary types are only supported by custom camera controllers).
+They will also have a description that is displayed to the user and the set of possible options. 
 
 Parameters can be simple or quite complex, depending on the behavior they change.
 
-> **Note** The parameter CAM_MODE needs to part of the parameter list. It maps to the command [MAV_CMD_SET_CAMERA_MODE](../messages/common.md#MAV_CMD_SET_CAMERA_MODE). It allows to expose different settings based on the mode, so photo settings in photo mode and video settings in video mode.
+> **Note** The parameter `CAM_MODE` must be part of the parameter list.
+  It maps to the command [MAV_CMD_SET_CAMERA_MODE](../messages/common.md#MAV_CMD_SET_CAMERA_MODE).
+  It enables exposure of different settings based on the mode, so photo settings in photo mode and video settings in video mode.
 
 #### Parameter Types
 


### PR DESCRIPTION
The param CAM_MODE is actually always needed, so we should mention it here.