### PR TITLE
High Latency Protocol 

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -64,5 +64,7 @@
   * [Terrain Protocol](services/terrain.md)
   * [Tunnel Protocol](services/tunnel.md)
   * [Open Drone ID Protocol (WIP)](services/opendroneid.md)
+  * [High Latency Protocol](services/high_latency.md)
+  
 * [Contributing](contributing/contributing.md)
 * [Support](about/support.md)

--- a/en/services/README.md
+++ b/en/services/README.md
@@ -31,3 +31,4 @@ The main microservices are shown in the sidebar (most are listed below):
 * [Terrain Protocol](../services/terrain.md)
 * [Tunnel Protocol](../services/tunnel.md)
 * [Open Drone ID Protocol (WIP)](../services/opendroneid.md)
+* [High Latency Protocol](../services/high_latency.md)

--- a/en/services/high_latency.md
+++ b/en/services/high_latency.md
@@ -1,0 +1,31 @@
+# High Latency
+
+High Latency links (e.g. Iridium Satellite links) can provide truly global connectivity, albeit with significant latency and high cost-per-message.
+Generally the cost and latency means that high-latency links should only be used when there is no lower-latency alternative, and when active they should only send essential information.
+
+The High Latency protocol provides two main mechanisms to support these goals:
+- [HIGH_LATENCY2](#HIGH_LATENCY2) 
+  - A heartbeat-like message for high latency links that contains all the most important telemetry.
+  - This is sent at low rate over the high latency link.
+- [MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY) 
+  - A command for enabling/disabling a high latency link.
+  - The GCS sends this to the vehicle to enable/disable sending information over the high latency link.
+    This might enabled if the user explicitly sets the high latency link as primary, or if all low latency links are lost.
+ 
+
+## Message/Enum Summary
+
+Message | Description
+-- | --
+<span id="HIGH_LATENCY2"></span>[HIGH_LATENCY2](../messages/common.md#HIGH_LATENCY2) | Message appropriate for high latency connections like Iridium (Version 2)
+
+
+Command | Description
+-- | --
+<span id="MAV_CMD_CONTROL_HIGH_LATENCY"></span>[MAV_CMD_CONTROL_HIGH_LATENCY](../messages/common.md#MAV_CMD_CONTROL_HIGH_LATENCY) | Request to start/stop transmitting over the high latency telemetry. 
+
+
+Enum | Description
+-- | --
+<span id="HL_FAILURE_FLAG"></span>[HL_FAILURE_FLAG](../messages/common.md#HL_FAILURE_FLAG) | Flags to report failure cases over the high latency telemtry.
+

--- a/en/services/high_latency.md
+++ b/en/services/high_latency.md
@@ -1,31 +1,34 @@
-# High Latency
+# High Latency Protocol
 
-High Latency links (e.g. Iridium Satellite links) can provide truly global connectivity, albeit with significant latency and high cost-per-message.
-Generally the cost and latency means that high-latency links should only be used when there is no lower-latency alternative, and when active they should only send essential information.
+High latency links (e.g. Iridium Satellite links) provide global connectivity, albeit with significant message latency and high cost-per-message.
+Generally the cost and latency means that high-latency links are only used when there is no lower-latency alternative, and when active the links should only send essential information.
 
-The High Latency protocol provides two main mechanisms to support these goals:
-- [HIGH_LATENCY2](#HIGH_LATENCY2) 
-  - A heartbeat-like message for high latency links that contains all the most important telemetry.
-  - This is sent at low rate over the high latency link.
-- [MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY) 
-  - A command for enabling/disabling a high latency link.
-  - The GCS sends this to the vehicle to enable/disable sending information over the high latency link.
-    This might enabled if the user explicitly sets the high latency link as primary, or if all low latency links are lost.
- 
+The protocol provides a heartbeat-like message ([HIGH_LATENCY2](#HIGH_LATENCY2)) for transmitting just the most important telemetry at low rate, and a command ([MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY)) for enabling/disabling the high latency link when needed (i.e. when no lower-latency link is available).
+
 
 ## Message/Enum Summary
 
 Message | Description
 -- | --
-<span id="HIGH_LATENCY2"></span>[HIGH_LATENCY2](../messages/common.md#HIGH_LATENCY2) | Message appropriate for high latency connections like Iridium (Version 2)
+<a id="HIGH_LATENCY2"></a>[HIGH_LATENCY2](../messages/common.md#HIGH_LATENCY2) | A heartbeat-like message that contains all the most important (but not time-sensitive) telemetry for sending over high latency links.
 
 
 Command | Description
 -- | --
-<span id="MAV_CMD_CONTROL_HIGH_LATENCY"></span>[MAV_CMD_CONTROL_HIGH_LATENCY](../messages/common.md#MAV_CMD_CONTROL_HIGH_LATENCY) | Request to start/stop transmitting over the high latency telemetry. 
+<span id="MAV_CMD_CONTROL_HIGH_LATENCY"></span>[MAV_CMD_CONTROL_HIGH_LATENCY](../messages/common.md#MAV_CMD_CONTROL_HIGH_LATENCY) | Command to start/stop transmitting high latency telemetry (`HIGH_LATENCY2`).
 
 
 Enum | Description
 -- | --
-<span id="HL_FAILURE_FLAG"></span>[HL_FAILURE_FLAG](../messages/common.md#HL_FAILURE_FLAG) | Flags to report failure cases over the high latency telemtry.
+<span id="HL_FAILURE_FLAG"></span>[HL_FAILURE_FLAG](../messages/common.md#HL_FAILURE_FLAG) | Flags to report failure cases over the high latency telemetry.
 
+
+## Sequences
+
+A GCS will typically have one primary link that is used for all vehicle communications, but may also have secondary links that it can switch to if needed (which will then become the primary link).
+
+The diagram below shows a GCS switching from a higher-latency primary link to a lower latency secondary link when one becomes available, and then back to the higher latency link when the primary link drops out.
+[MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY) is sent to turn the high latency link on and off.
+
+
+[![](https://mermaid.ink/img/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgTm90ZSBvdmVyIEdDUyxEcm9uZTogRHJvbmUgY29ubmVjdGVkIG92ZXIgSEwgY29ubmVjdGlvblxuICAgIERyb25lLT4-R0NTOiBISUdIX0xBVEVOQ1kyXG4gICAgRHJvbmUtPj5HQ1M6IC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IExvd2VyIGxhdGVuY3kgY29ubmVjdGlvbiBhdmFpbGFibGUuIFN0b3AgSEwgY29ubmVjdGlvbi5cbiAgICBHQ1MtPj5Ecm9uZTogTUFWX0NNRF9DT05UUk9MX0hJR0hfTEFURU5DWShwYXJhbTE9MClcbiAgICBEcm9uZS0-PkdDUzogTm9ybWFsIGxhdGVuY3kgbWVzc2FnZXMgb3ZlciBuZXcgY2hhbm5lbC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IFByaW1hcnkgY29ubmVjdGlvbiBkcm9wcyBvdXQuIFN0YXJ0IEhMIGNvbm5lY3Rpb24uXG4gICAgR0NTLT4-RHJvbmU6IE1BVl9DTURfQ09OVFJPTF9ISUdIX0xBVEVOQ1kocGFyYW0xPTEpXG4gICAgRHJvbmUtPj5HQ1M6IEhJR0hfTEFURU5DWTIiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgTm90ZSBvdmVyIEdDUyxEcm9uZTogRHJvbmUgY29ubmVjdGVkIG92ZXIgSEwgY29ubmVjdGlvblxuICAgIERyb25lLT4-R0NTOiBISUdIX0xBVEVOQ1kyXG4gICAgRHJvbmUtPj5HQ1M6IC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IExvd2VyIGxhdGVuY3kgY29ubmVjdGlvbiBhdmFpbGFibGUuIFN0b3AgSEwgY29ubmVjdGlvbi5cbiAgICBHQ1MtPj5Ecm9uZTogTUFWX0NNRF9DT05UUk9MX0hJR0hfTEFURU5DWShwYXJhbTE9MClcbiAgICBEcm9uZS0-PkdDUzogTm9ybWFsIGxhdGVuY3kgbWVzc2FnZXMgb3ZlciBuZXcgY2hhbm5lbC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IFByaW1hcnkgY29ubmVjdGlvbiBkcm9wcyBvdXQuIFN0YXJ0IEhMIGNvbm5lY3Rpb24uXG4gICAgR0NTLT4-RHJvbmU6IE1BVl9DTURfQ09OVFJPTF9ISUdIX0xBVEVOQ1kocGFyYW0xPTEpXG4gICAgRHJvbmUtPj5HQ1M6IEhJR0hfTEFURU5DWTIiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)


### PR DESCRIPTION
@DonLakeFlyer This is draft docs for the High latency API following our discussion [here](https://github.com/mavlink/qgroundcontrol/pull/9101#issuecomment-704524299). 

Can you please let me know if these assumptions are correct (yes, no, maybe, don't know)
1. Vehicle pretty much _only_ emits HIGH_LATENCY2 and it acts as both heartbeat and as essential telemetry. 
2. Vehicle doesn't emit other messages.
3. Vehicle only emits HIGH_LATENCY2  message when commanded by MAV_CMD_CONTROL_HIGH_LATENCY 
4. QGC sends MAV_CMD_CONTROL_HIGH_LATENCY when an HL link becomes the primary. 
5. The implication of 4 is that the connection is unlike a normal LL connection where you start communicating on the same link by sending heartbeats and you know that the connection has fallen out when the heartbeat messages stop. In this case the link is only "theoretical" - QGC knows about it and can connect to it, but it isn't actually starting to monitor for HL2 messages until after sending that command. Presumably it still uses a timeout for when HL message not received for ages.

Is that all about right/can you confirm? Do you know what rate QGC expects for a HIGH_LATENCY2 timeout?

Note, I have marked `HIGH_LATENCY` as deprecated in favour of `HIGH_LATENCY2`: https://github.com/mavlink/mavlink/pull/1505

