### PR TITLE
Mission - clarify how mission param 5/6 used if NOT positional data

### DIFF
--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -65,8 +65,8 @@ Field Name | Type | Values | Description
 target_system | uint8_t | | System ID
 target_component | uint8_t | | Component ID
 seq | uint16_t |  | Sequence number for item within mission (indexed from 0).
-frame | uint8_t | MAV_FRAME | The coordinate system of the waypoint.<br>ArduPilot and PX4 both only support global frames in MAVLink commands (local frames may be supported if the same command is sent via the command protocol).
-mission_type | uint8_t | MAV_MISSION_TYPE | [Mission type](#mission_types).
+frame | uint8_t | [MAV_FRAME](#MAV_FRAME) | The coordinate system of the waypoint.<br>ArduPilot and PX4 both only support global frames in MAVLink commands (local frames may be supported if the same command is sent via the command protocol).
+mission_type | uint8_t | [MAV_MISSION_TYPE](#MAV_MISSION_TYPE) | [Mission type](#mission_types).
 current | uint8_t | false:0, true:1 | When downloading, whether the item is the current mission item.
 autocontinue | uint8_t | | Autocontinue to next waypoint when the command completes.
 
@@ -127,7 +127,6 @@ A number of local frames are also specified.
 Local frame position values that are sent in integer field parameters must be encoded as *position in meters x 1E4* (e.g. 5m would be encoded and sent as 50000).
 If sent in messages `float` parameter fields the value should be sent as-is.
 
-
 > **Note** Don't use the non-INT *global frames* in mission items (e.g. `MAV_FRAME_GLOBAL_RELATIVE_ALT`).
   These are intended to be used with messages that have `float` fields for positional information, e.g.: `MISSION_ITEM` (deprecated), `COMMAND_LONG`.
   If these frames are used, position values should be sent unencoded (i.e. no need to multiply by 1E7).
@@ -137,6 +136,18 @@ If sent in messages `float` parameter fields the value should be sent as-is.
   This will result in the value being rounded when it is sent in the integer value, which will make the value unusable.
   In practice, many systems will assume you have encoded the value, but you should test this for your particular flight stack.
   Better just to use the correct frames!
+  
+<span></span>
+> **Warning** Don't use [MAV_FRAME_MISSION](../messages/common.md#MAV_FRAME_MISSION) for mission items that contain positional data; this does not correspond to any particular real frame, and so will be ambiguous.
+  `MAV_FRAME_MISSION` should be used for mission items that use params5 and param6 for other purposes.
+
+## Param 5, 6 For Non-Positional Data
+
+Param5, param6, param7 may also be used for non-positional information.
+In this case the [MISSION_ITEM_INT.frame](#MISSION_ITEM_INT) should be set to [MAV_FRAME_MISSION](../messages/common.md#MAV_FRAME_MISSION) (this is equivalent to say "the frame data is irrelevant").
+
+As param5 and param6 are sent in *integer* fields, generally you should design mission items/MAV_CMDs such that these only include integer data (and are sent as-is/unscaled).
+If these must be used for real numbers and scaling is required, then this must be noted in the mission item itself.
 
 
 ## Operations {#operations}


### PR DESCRIPTION
Essentially you set MAV_FRAME_MISSION (meaning "frame not applicable"). A well designed message should only use and INT for these fields. If a float must be sent in them then it will need to be scaled in some way, and that should be recorded in the mav_cmd itself.

@auturgy FYI, this came up in a discussion I had about what MAV_FRAME_MISSION should be used for. 