### PR TITLE
ftp: notes on CRC32 standard

### DIFF
--- a/en/services/ftp.md
+++ b/en/services/ftp.md
@@ -443,3 +443,13 @@ Everything is run by the master (QGC in this case); the slave simply responds to
 The MAVLink receiver thread copies an incoming request verbatim from the MAVLink buffer into a request queue, and queues a low-priority work item to handle the packet. This avoids trying to do file I/O on the MAVLink receiver thread, as well as avoiding yet another worker thread. The worker is responsible for directly queuing replies, which are sent with the same sequence number as the request.
 
 The implementation on PX4 only supports a single session.
+
+## CRC32 Implementation
+
+The CRC32 calculation used by MAVLink FTP is similar to the ISO 3309 standard based on the polygon 0x04C11DB7. This is also referred to the CRC32 based on Gary Brown's work.
+
+The difference of the MAVLink implementation versus the standard are:
+- Start at 0 instead of `0xFFFFFFFF`.
+- Missing final XOR out operation with `0xFFFFFFFF`.
+
+The effects of the initial value and final XOR operation are documented in this [brief tutorial on CRC computation of the Linux kernel](https://github.com/torvalds/linux/blob/master/Documentation/staging/crc32.rst).


### PR DESCRIPTION
This should describe what CRC32 is used and how it differes from the ISO 3309 standard.

Related to https://github.com/mavlink/mavlink/issues/1219.
Closes #258.