### PR TITLE
Clarify use of MAV_TYPE and what compid to use

### DIFF
--- a/en/services/heartbeat.md
+++ b/en/services/heartbeat.md
@@ -3,16 +3,17 @@
 The heartbeat protocol is used to advertise the existence of a system on the MAVLink network, along with its system and component id, vehicle type, flight stack, component type, and flight mode.
 
 The heartbeat allows other components to:
-- discover systems that are connected to the network and infer when they have disconnected. A system is considered to be *connected to the network* if its [HEARTBEAT](../messages/common.md#HEARTBEAT) message is regularly received, and disconnected if a number of expected messages are not received.
-- handle other messages from the system appropriately, based on system type and other properties (e.g. layout a GCS interface based on vehicle type).
-- route messages to systems on different interfaces.
+- discover systems that are connected to the network and infer when they have disconnected.
+  A component is considered to be *connected to the network* if its [HEARTBEAT](../messages/common.md#HEARTBEAT) message is regularly received, and disconnected if a number of expected messages are not received.
+- handle other messages from the component appropriately, based on component type and other properties (e.g. layout a GCS interface based on vehicle type).
+- [route](../guide/routing.md) messages to systems on different interfaces.
 
 
 ## Message/Enum Summary
 
 Message | Description
 -- | --
-<span id="HEARTBEAT"></span>[HEARTBEAT](../messages/common.md#HEARTBEAT) | Broadcast that a system is present and responding, along with its type and other properties.
+<span id="HEARTBEAT"></span>[HEARTBEAT](../messages/common.md#HEARTBEAT) | Broadcast that a MAVLink component is present and responding, along with its type ([MAV_TYPE](#MAV_TYPE)) and other properties.
 
 Enum | Description
 -- | --
@@ -29,7 +30,7 @@ Components must regularly broadcast their `HEARTBEAT` and monitor for heartbeats
 The rate at which the `HEARTBEAT` message must be broadcast, and how many messages may be "missed" before a system is considered to have timed out/disconnected from the network, depends on the channel (it is not defined by MAVLink).
 On RF telemetry links, components typically publish their heartbeat at 1 Hz and consider another system to have disconnected if four or five messages are not received.
 
-A system may choose not to broadcast information if it does not detect another system, and it will continue to send messages to a system while it is receiving heartbeats. 
+A component may choose not to send or broadcast information on a channel (other than the `HEARTBEAT`) if it does not detect another system, and it will continue to send messages to a system while it is receiving heartbeats.
 Therefore it is important that systems:
 - broadcast a heartbeat even when not commanding the remote system.
 - do not broadcast a heartbeat when they are in a faulted state (i.e. do not publish a heartbeat from a separate thread that is unaware of the state of the rest of the component).
@@ -37,9 +38,27 @@ Therefore it is important that systems:
 
 ## Connecting to a GCS or MAVLink API {#gcs}
 
-The `HEARTBEAT` is also used by GCS (or Developer API) to determine if can *connect to a vehicle* in order to collect telemetry and send missions/commands.
+The `HEARTBEAT` may also used by GCS (or Developer API) to determine if it **can** connect to a vehicle in order to collect telemetry and send missions/commands.
 
 For example, *QGroundControl* will only connect to a vehicle system (i.e. not another GCS, gimbal, or onboard controller), and also checks that it has a non-zero system ID before displaying the vehicle connected message.
 QGC also uses the specific type of vehicle and other heartbeat information to control layout of the GUI.
 
 > **Note** The specific code for connecting to *QGroundControl* can be found in [MultiVehicleManager.cc](https://github.com/mavlink/qgroundcontrol/blob/master/src/Vehicle/MultiVehicleManager.cc) (see `void MultiVehicleManager::_vehicleHeartbeatInfo`).
+
+## Component Identity
+
+The _type_ ([MAV_TYPE](#MAV_TYPE)) of a component is obtained from its [HEARTBEAT.type](#HEARTBEAT) field.
+- A flight controller component will use a `MAV_TYPE` corresponding to a particular vehicle - e.g. `MAV_TYPE_FIXED_WING`, `MAV_TYPE_QUADROTOR` etc. (the use of any of these "vehicle types" indicates the component is a flight controller).
+- Any other component should use its actual type, e.g. `MAV_TYPE_GIMBAL`, `MAV_TYPE_BATTERY`, etc.
+
+Every component must have a system-unique component id, which is used for routing and for identifying multiple instances of a particular component type.
+
+> **Warning** Historically the component id was also used to determine the component type.
+  New code must not make any assumption about the type from the id used (type is determined from `HEARTBEAT.type`).
+
+MAVLink recommends that *by default* components use a type-appropriate component id from [MAV_COMPONENT](../messages/common.md#MAV_COMPONENT), and provide an interface to change the component id if needed.
+For example, a gimbal component might use use [MAV_COMP_ID_GIMBAL](../messages/common.md#MAV_COMP_ID_GIMBAL) or [MAV_COMP_ID_GIMBAL`n`](../messages/common.md#MAV_COMP_ID_GIMBAL2), and should not use `MAV_COMP_ID_GPS2`.
+
+> **Tip** Using type-specific component ids:
+  - makes id clashes less likely "out of the box" (unless two components of the same type are present on the same system).
+  - reduces the impact on legacy code that determines component type from the id. 

--- a/en/services/heartbeat.md
+++ b/en/services/heartbeat.md
@@ -57,8 +57,8 @@ Every component must have a system-unique component id, which is used for routin
   New code must not make any assumption about the type from the id used (type is determined from `HEARTBEAT.type`).
 
 MAVLink recommends that *by default* components use a type-appropriate component id from [MAV_COMPONENT](../messages/common.md#MAV_COMPONENT), and provide an interface to change the component id if needed.
-For example, a gimbal component might use use [MAV_COMP_ID_GIMBAL](../messages/common.md#MAV_COMP_ID_GIMBAL) or [MAV_COMP_ID_GIMBAL`n`](../messages/common.md#MAV_COMP_ID_GIMBAL2), and should not use `MAV_COMP_ID_GPS2`.
+For example, a camera component might use any of the [MAV_COMP_ID_CAMERA`n`](../messages/common.md#MAV_COMP_ID_GIMBAL) ids, and should not use `MAV_COMP_ID_GPS2`.
 
 > **Tip** Using type-specific component ids:
-  - makes id clashes less likely "out of the box" (unless two components of the same type are present on the same system).
-  - reduces the impact on legacy code that determines component type from the id. 
+>  - makes id clashes less likely "out of the box" (unless two components of the same type are present on the same system).
+>  - reduces the impact on legacy code that determines component type from the id. 


### PR DESCRIPTION
Historically component ids were used for determining component type. However about a year ago it was decided that the type of a component should come from its heartbeat, and that any component id can be used. This has some benefits because in theory now a component id is just used for routing. 

Note though, even though component ids can't be relied on to infer type, it still makes sense to use type-specific ids for a default value. Reason being that this reduces the chance of clashes if you add a new gimbal, say to your system. [of course you still need a way to set component and system ids for a system if the default is already used - e.g if you had two GPS].

This change captures those implications.

Note, I don't love it. Mostly because there is SO much legacy code that still assumes the IDs - and I don't see that changing. 