### PR TITLE
Make crowdin translation of Korean display

### DIFF
--- a/LANGS.md
+++ b/LANGS.md
@@ -1,4 +1,4 @@
 * [English](en/)
 * [Chinese (中文)](zh/) 
-* [Korean (한국어)](kr/)
+* [Korean (한국어)](ko/)
 <!-- * [Español](es/) -->


### PR DESCRIPTION
Replaces #271

The Korean translation from crowdin is only 1% while the old version is more complete. However the old version is getting progressively out of date - so it is "deceptive".

This basically means that we lose the translations but at least we start from a fresh slate. I have however kept the old translations for reference, for now. 