### PR TITLE
Add mavlink crc topic

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -28,6 +28,7 @@
   * [Scripts](guide/scripts.md)
   * [MAVLink XML Schema](guide/xml_schema.md)
   * [Defining XML Enums/Messages](guide/define_xml_element.md)
+  * [MAVLink CRCs](guide/crc.md)
   * [Dialects](messages/README.md)
     * [ardupilotmega.xml](messages/ardupilotmega.md)
     * [ASLUAV.xml](messages/ASLUAV.md)

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -28,7 +28,7 @@
   * [Scripts](guide/scripts.md)
   * [MAVLink XML Schema](guide/xml_schema.md)
   * [Defining XML Enums/Messages](guide/define_xml_element.md)
-  * [MAVLink CRCs](guide/crc.md)
+  * [MAVLink CRC](guide/crc.md)
   * [Dialects](messages/README.md)
     * [ardupilotmega.xml](messages/ardupilotmega.md)
     * [ASLUAV.xml](messages/ASLUAV.md)

--- a/en/guide/README.md
+++ b/en/guide/README.md
@@ -16,4 +16,5 @@ The topics linked from the sidebar (and listed below):
 * [Scripts](../guide/scripts.md)
 * [MAVLink XML Schema](../guide/xml_schema.md)
 * [Defining XML Enums/Messages](../guide/define_xml_element.md)
+* [MAVLink CRCs](../guide/crc.md)
 * [Dialects](../messages/README.md)

--- a/en/guide/crc.md
+++ b/en/guide/crc.md
@@ -19,4 +19,4 @@ The effects of the initial value and final XOR operation are documented in this 
 
 This implementation is currently used in:
 - [File Transfer Protocol (FTP)](../services/ftp.md)
-* [Parameter Protocol > PX4 Implementation](../services/parameter.md#px4) (Stack-specific hash of cached parameters).
+* [Parameter Protocol > PX4 Implementation](../services/parameter.md#px4) (Implementation-specific hash of cached parameters).

--- a/en/guide/crc.md
+++ b/en/guide/crc.md
@@ -1,12 +1,14 @@
 # MAVLink CRC
 
-MAVLink code that needs to use a Cyclic Redundancy Check (CRC) should choose the CRC32 implementation described below.
+MAVLink services that need to use a Cyclic Redundancy Check (CRC) should choose the CRC32 algorithm described below.
 
 > **Note** Using the same CRC implementation for all cases means that only one implementation is required. 
   Do not introduce another unless there without a compelling technical reason.
 
+<span></span>
+> **Note** This CRC is [used for higher level services](#implementations) (it is not related to the CRC16 used for the checksum in [MAVLink serialization](serialization.md#checksum)).
 
-## CRC32 Implementation
+## CRC32 Algorithm
 
 The CRC32 algorithm used by MAVLink is similar to (but different from) the ISO 3309 standard based on the polygon 0x04C11DB7.
 It is commonly referred to as "the CRC32 based on Gary Brown's work".
@@ -17,6 +19,8 @@ The difference of MAVLink's implementation versus the standard are:
 
 The effects of the initial value and final XOR operation are documented in this [brief tutorial on CRC computation of the Linux kernel](https://github.com/torvalds/linux/blob/master/Documentation/staging/crc32.rst).
 
+## Implementations
+
 This implementation is currently used in:
 - [File Transfer Protocol (FTP)](../services/ftp.md)
-* [Parameter Protocol > PX4 Implementation](../services/parameter.md#px4) (Implementation-specific hash of cached parameters).
+- [Parameter Protocol > PX4 Implementation](../services/parameter.md#px4) (Implementation-specific hash of cached parameters).

--- a/en/guide/crc.md
+++ b/en/guide/crc.md
@@ -1,0 +1,22 @@
+# MAVLink CRC
+
+MAVLink code that needs to use a Cyclic Redundancy Check (CRC) should choose the CRC32 implementation described below.
+
+> **Note** Using the same CRC implementation for all cases means that only one implementation is required. 
+  Do not introduce another unless there without a compelling technical reason.
+
+
+## CRC32 Implementation
+
+The CRC32 algorithm used by MAVLink is similar to (but different from) the ISO 3309 standard based on the polygon 0x04C11DB7.
+It is commonly referred to as "the CRC32 based on Gary Brown's work".
+
+The difference of MAVLink's implementation versus the standard are:
+- Start at 0 instead of `0xFFFFFFFF`.
+- Missing final XOR out operation with `0xFFFFFFFF`.
+
+The effects of the initial value and final XOR operation are documented in this [brief tutorial on CRC computation of the Linux kernel](https://github.com/torvalds/linux/blob/master/Documentation/staging/crc32.rst).
+
+This implementation is currently used in:
+- [File Transfer Protocol (FTP)](../services/ftp.md)
+* [Parameter Protocol > PX4 Implementation](../services/parameter.md#px4) (Stack-specific hash of cached parameters).

--- a/en/services/ftp.md
+++ b/en/services/ftp.md
@@ -446,14 +446,7 @@ The implementation on PX4 only supports a single session.
 
 ## CRC32 Implementation
 
-The CRC32 algorithm used by MAVLink FTP is similar to (but different from) the ISO 3309 standard based on the polygon 0x04C11DB7.
-It is commonly referred to as "the CRC32 based on Gary Brown's work".
-
-The difference of the MAVLink implementation versus the standard are:
-- Start at 0 instead of `0xFFFFFFFF`.
-- Missing final XOR out operation with `0xFFFFFFFF`.
-
-The effects of the initial value and final XOR operation are documented in this [brief tutorial on CRC computation of the Linux kernel](https://github.com/torvalds/linux/blob/master/Documentation/staging/crc32.rst).
+The CRC32 algorithm used by MAVLink FTP is described in [MAVLink CRCs](../guide/crc.md).
 
 ## MAVLink FTP URL Scheme
 

--- a/en/services/parameter.md
+++ b/en/services/parameter.md
@@ -218,8 +218,9 @@ PX4 implements the protocol in a way that is compatible with this specification.
 Only float and Int32 parameters are used.
 
 PX4 additionally provides a mechanism that allows a GCS to *cache* parameters, which significantly reduces ready-to-use time for the GCS if parameters have not been changed since the previous parameter sync.
-The way that this mechanism works is that when the list of parameters is requested, PX4 first sends a `PARAM_VALUE` with the `param_index` of `INT16_MAX` (in code, referred to as `PARAM_HASH`) containing a *hash* of the parameter set. 
-This hash is calculated by computing the CRC32 over all param names and values (see the `param_hash_check()` in source [here](https://github.com/PX4/Firmware/blob/v1.9.0-alpha/src/lib/parameters/parameters.cpp#L1329)). 
+The way that this mechanism works is that when the list of parameters is requested, PX4 first sends a `PARAM_VALUE` with the `param_index` of `INT16_MAX` (in code, referred to as `PARAM_HASH`) containing a *hash* of the parameter set.
+
+This hash is calculated by computing the [MAVLink CRC32](../guide/crc.md) over all param names and values (see the `param_hash_check()` in source [here](https://github.com/PX4/Firmware/blob/v1.9.0-alpha/src/lib/parameters/parameters.cpp#L1329)). 
 If the GCS has a matching hash value it can immediately start using its cached parameters (rather than having to wait while all the rest of the parameters upload).
 
 Source files:


### PR DESCRIPTION
@julianoes As discussed.

At the moment is refers to CRCs rather than CRC32, because I wanted to check what you think about the "need" to talk about the CRC used in the checksum here: https://mavlink.io/en/guide/serialization.html#checksum

if you think this should just be ignored, then I would probably rename the heading CRC32.