### PR TITLE
Add fastMavlink C library

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -61,6 +61,7 @@ Go      | [gomavlib](https://github.com/gswly/gomavlib) | &check; | &check; | &c
 Go      | [go-mavlink1](https://github.com/mgr9525/go-mavlink1) | &check; | &cross;|  &cross; | Golang MAVLink v1
 Haskell | [HaskMavlink](https://github.com/SweeWarman/HaskMavlink)| &cross; | &check; | &cross; | 
 Rust | [rust-mavlink](https://github.com/mavlink/rust-mavlink)| &check; | &check; |  | Rust MAVLink generated code. Has [tests](https://github.com/mavlink/rust-mavlink/tree/master/tests) and [docs](https://docs.rs/mavlink/latest/mavlink/).
+C       | [fastMavlink](https://github.com/olliw42/fastmavlink) | &check; | &check; |  &cross; | Highly efficient C library with python code generators. Has [docs](https://github.com/olliw42/fastmavlink), [examples](https://github.com/olliw42/fastmavlink/tree/master/examples), [test](https://github.com/olliw42/fastmavlink/tree/master/tests), support for [routing](https://github.com/olliw42/fastmavlink#router) and [mavgen mimicry](https://github.com/olliw42/fastmavlink#pymavlink-mavgen-mimicry).
 
 
 ## Prebuilt MAVLink C Libraries {#prebuilt_libraries}

--- a/en/getting_started/use_libraries.md
+++ b/en/getting_started/use_libraries.md
@@ -19,3 +19,4 @@ The linked documents explain how to use the MAVLink libraries for different prog
 * [Go (*gomavlib*)](https://pkg.go.dev/github.com/aler9/gomavlib)
 * [Go (*go-mavlink1*)](https://github.com/mgr9525/go-mavlink1)
 * [Rust (*rust-mavlink*)](https://docs.rs/mavlink/latest/mavlink/)
+* [C (*fastMavlink*)](https://github.com/olliw42/fastmavlink)


### PR DESCRIPTION
Hey folks

I'd like to add the [fastMavlink](https://github.com/olliw42/fastmavlink) C library to the docs. 

This is strongly motivated by the discussion in https://github.com/mavlink/mavlink-devguide/pull/190, which essentially says "everything gets to go in" (with "everything" of course subject to common sense). It looks to me that the situation for the fastMavlink library is not different to e.g. that for the Go library discussed there.

Also, I do have various pieces of the fastMavlink code base in use since 2 years (it all started with https://github.com/mavlink/mavlink/pull/1127) in my STorM32 project, which evolved as [mavlink light](https://github.com/olliw42/mavlink/tree/light) to finally becoming fastMavlink. I am using the fastMavlink library since several months in my STorM32 and Mavlink for OpenTx projects. So, to sum it up, I think the library can claim some level of majurity.

Hence this PR :)

