### PR TITLE
Separate project and non-project generators

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -11,9 +11,8 @@ Messages are [defined within XML files](messages/README.md).
 Each XML file defines the message set supported by a particular MAVLink system, also referred to as a "dialect". 
 The reference message set that is implemented by *most* ground control stations and autopilots is defined in [common.xml](messages/common.md) (most dialects *build on top of* this definition).
 
-The [MAVLink toolchain](https://github.com/mavlink/mavlink/) uses the XML message definitions to [generate](getting_started/generate_libraries.md) MAVLink libraries for each of the [supported programming languages](#supported_languages).
-Drones, ground control stations, and other MAVLink systems use the generated libraries to communicate.
-These are typically MIT-licensed, and can therefore be *used* without limits in any closed-source application without publishing the source code of the closed-source application.
+[Code generators](getting_started/generate_libraries.md) create software libraries for [specific programming languages](#supported_languages) from these XML message definitions, which can then be used by drones, ground control stations, and other MAVLink systems to communicate.
+The generated libraries are typically MIT-licensed, and can therefore be *used* without limits in any closed-source application without publishing the source code of the closed-source application.
 
 > **Note** The C reference implementation is a header-only library that is highly optimized for resource-constrained systems with limited RAM and flash memory. 
   It is field-proven and deployed in many products where it serves as interoperability interface between components of different manufacturers.
@@ -33,15 +32,13 @@ MAVLink was first released early 2009 by Lorenz Meier and has now a [significant
 
 ## Language/Generator List {#supported_languages}
 
-The MAVLink project includes the [mavgen](getting_started/generate_libraries.md#mavgen) and [mavgenerate](getting_started/generate_libraries.md#mavgenerate) tools that can be used to create MAVLink libraries for a number of programming languages.
-The organisation also includes [rust-mavlink](https://github.com/mavlink/rust-mavlink) for generating Rust MAVLink libraries.
-Additional generators are delivered by a number of other (independent) projects.
+The sections below lists MAVLink generators and their associated programming languages.
 
-> **Note** The MAVLink project has not validated and does not provide technical support for generators other than *mavgen*, *mavgenerate*, and *rust-mavlink*.
+### MAVLink Project Generators/Languages
 
-The table below shows the available languages/generators, along with their support for MAVLink v1, [MAVLink 2](guide/mavlink_2.md) and [Message Signing](guide/message_signing.md).
+The MAVLink organisation provides (and supports) the [mavgen](getting_started/generate_libraries.md#mavgen), [mavgenerate](getting_started/generate_libraries.md#mavgenerate) and [rust-mavlink](https://github.com/mavlink/rust-mavlink) tools.
 
-Language | Generator | MAVLink v1 | MAVLink v2 | Signing | Notes
+Language | Generator | MAVLink v1 | [MAVLink 2](guide/mavlink_2.md) | [Signing](guide/message_signing.md) | Notes
 :--- | :--- | :---:| :---: | :---
 C       | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; | This is the MAVLink project reference implementation. [Generated libraries](#prebuilt_libraries) are also published for both protocol versions.
 C++11   | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; |  | 
@@ -49,19 +46,27 @@ Python (2.7+, 3.3+) | [mavgen](getting_started/generate_libraries.md#mavgen) | &
 C#      | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; |  |  | | 
 Objective C | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | | | 
 Java    | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | | | | 
-Java    | [dronefleet/mavlink](https://github.com/dronefleet/mavlink) | &check; | &check; | &check; | *Idiomatic* Java SDK/API for MAVLink. Provides a gradle plugin for the code generator.
 JavaScript (Stable) | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &cross; | Old mavgen JavaScript binding (has known bugs and no test suite). 
 JavaScript (NextGen) | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; | New mavgen JavaScript library. Full test suite, resulting library produces binary compatible output compared to C bindings. Slightly incompatible with previous version, but not hard to migrate.
 TypeScript/JavaScript | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &cross; | TypeScript classes which can be used with [node-mavlink](https://github.com/ifrunistuttgart/node-mavlink).
 Lua     | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &cross; | Lua library. Does not support zero trimming of MAVLink 2 messages.
 WLua (Wireshark Lua bindings)| [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | NA | Allow MAVLink-aware packet inspection in Wireshark. Generated lua scripts should be copied to the Wireshark plugin directory (e.g. **wireshark/plugins/mavlink.lua**).
 Swift   | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | | | 
+Rust | [rust-mavlink](https://github.com/mavlink/rust-mavlink)| &check; | &check; |  | Rust MAVLink generated code. Has [tests](https://github.com/mavlink/rust-mavlink/tree/master/tests) and [docs](https://docs.rs/mavlink/latest/mavlink/).
+
+
+### External Generators/Languages
+
+The following generators are delivered by independent projects (and supported by those projects).
+
+Language | Generator | MAVLink v1 | [MAVLink 2](guide/mavlink_2.md) | [Signing](guide/message_signing.md) | Notes
+:--- | :--- | :---:| :---: | :---
+C       | [fastMavlink](https://github.com/olliw42/fastmavlink) | &check; | &check; |  &cross; | Highly efficient C library with python code generators. Has [docs](https://github.com/olliw42/fastmavlink), [examples](https://github.com/olliw42/fastmavlink/tree/master/examples), [test](https://github.com/olliw42/fastmavlink/tree/master/tests), support for [routing](https://github.com/olliw42/fastmavlink#router) and [mavgen mimicry](https://github.com/olliw42/fastmavlink#pymavlink-mavgen-mimicry).
 Clojure | [clj-mavlink](https://github.com/WickedShell/clj-mavlink) | &check; | &check; | &check; | Clojure MAVLink Bindings.
 Go      | [gomavlib](https://github.com/gswly/gomavlib) | &check; | &check; | &check; | Go library with support for MAVLink 1, 2 and signing, test suite, and [documentation](https://pkg.go.dev/github.com/aler9/gomavlib)
 Go      | [go-mavlink1](https://github.com/mgr9525/go-mavlink1) | &check; | &cross;|  &cross; | Golang MAVLink v1
 Haskell | [HaskMavlink](https://github.com/SweeWarman/HaskMavlink)| &cross; | &check; | &cross; | 
-Rust | [rust-mavlink](https://github.com/mavlink/rust-mavlink)| &check; | &check; |  | Rust MAVLink generated code. Has [tests](https://github.com/mavlink/rust-mavlink/tree/master/tests) and [docs](https://docs.rs/mavlink/latest/mavlink/).
-C       | [fastMavlink](https://github.com/olliw42/fastmavlink) | &check; | &check; |  &cross; | Highly efficient C library with python code generators. Has [docs](https://github.com/olliw42/fastmavlink), [examples](https://github.com/olliw42/fastmavlink/tree/master/examples), [test](https://github.com/olliw42/fastmavlink/tree/master/tests), support for [routing](https://github.com/olliw42/fastmavlink#router) and [mavgen mimicry](https://github.com/olliw42/fastmavlink#pymavlink-mavgen-mimicry).
+Java    | [dronefleet/mavlink](https://github.com/dronefleet/mavlink) | &check; | &check; | &check; | *Idiomatic* Java SDK/API for MAVLink. Provides a gradle plugin for the code generator.
 
 
 ## Prebuilt MAVLink C Libraries {#prebuilt_libraries}


### PR DESCRIPTION
This separates the project owned generators from the external generators and puts them in alphabetic order. The reason for this is that it makes it easier to highlight what is supported by the project and what is not. 