### PR TITLE
Installation move to Python3 only

### DIFF
--- a/en/getting_started/installation.md
+++ b/en/getting_started/installation.md
@@ -22,7 +22,7 @@ If you are creating new XML definitions you should also install lxml and libxml2
 
 To install the MAVLink tools:
 
-1. Install Python 3.3+:
+1. Install Python 3.6+:
    * **Windows:** Download from [Python for Windows](https://www.python.org/downloads/)
    * **Ubuntu Linux** Python 3 is present on 18.04 and 20.04 by default but you will need to install the *pip3* package manager:
      ```

--- a/en/getting_started/installation.md
+++ b/en/getting_started/installation.md
@@ -9,23 +9,24 @@ including both [XML message definitions](../messages/README.md) and the GUI/comm
 
 ## Prerequisites
 
-The requirements for using the *MAVLink tools* are: 
+The requirements for using the *MAVLink generator* are: 
 
-* Python 3.3+ (recommended) or Python 2.7+
+* Python 3.3+
 * Python [future](http://python-future.org/) module
-* (Optional) Python [TkInter](https://wiki.python.org/moin/TkInter) module (required to use the GUI tool).
+* [TkInter](https://wiki.python.org/moin/TkInter) (required to use the GUI tool).
 * `PYTHONPATH` environment variable must be set to the directory path containing the *mavlink* repository.
 
-## Installation Steps
+If you are creating new XML definitions you should also install lxml and libxml2 for XML validation and formatting.
 
-The main installation steps are:
+## Installation
 
-1. Install Python 3.3+ (or Python 2.7+):
+To install the MAVLink tools:
+
+1. Install Python 3.3+:
    * **Windows:** Download from [Python for Windows](https://www.python.org/downloads/)
-   * **Ubuntu Linux 18.04:** Python 3 (and Python 2.7+) are already present. 
-     If you are using Python3 you will need to install the *pip3* package manager:
+   * **Ubuntu Linux** Python 3 is present on 18.04 and 20.04 by default but you will need to install the *pip3* package manager:
      ```
-     sudo apt-get install python3-pip
+     sudo apt install python3-pip
      ```
 1. Install the *future* module:
    * **Windows:**
@@ -33,34 +34,26 @@ The main installation steps are:
      pip3 install future
      ```
    * **Linux:**
-   
-     Python 3:
      ```
      pip3 install --user future
      ```
-     Python 2:
+1. (Recommended) Install modules for XML validation and formatting:
+   * **Linux:**
      ```
-     pip install --user future
-     ```
-1. (Optionally) Install TkInter
+     sudo apt install python3-lxml libxml2-utils
+     ```	 
+1. (Optional) Install TkInter
     * **Windows:** Installed already as part of *Python for Windows*
     * **Linux:** Enter the following terminal command:
-    
-      Python 3:
       ```
-      sudo apt-get install python3-tk
-      ```
-      Python 2:
-      ```
-      sudo apt-get install python-tk
+      sudo apt install python3-tk
       ```
 1. Clone the [mavlink repo](https://github.com/mavlink/mavlink) (or your fork) into a user-writable directory:
    ```
    git clone https://github.com/mavlink/mavlink.git --recursive
    ```
 1. Set `PYTHONPATH` to the directory path containing your *mavlink* repository.
-   * **Windows:** `set PYTHONPATH=C:\your_path_to_mavlink_clone`
-   * **Linux:** `PYTHONPATH=your_path_to_mavlink_clone`
+   * **Windows:** `set PYTHONPATH=C:\path_to_root_of_cloned_mavlink_repository`
+   * **Linux:** `PYTHONPATH=path_to_root_of_cloned_mavlink_repository`
 
 Now you are ready to [Generate MAVLink Libraries](../getting_started/generate_libraries.md).
-


### PR DESCRIPTION
Python 2 is pretty much end of life. 

This simplifies the instructions by removing the interleaved Python2 instructions. It also adds info on installing the xml validation tools and linter on Ubuntu. It does not do this for Windows (it should, but I don't see that as urgent). 