### PR TITLE
Clarify HIGH_LATENCY2 and HEARTBEAT

### DIFF
--- a/en/services/high_latency.md
+++ b/en/services/high_latency.md
@@ -17,7 +17,7 @@ In order to reduce traffic to the bare minimum, some of the fundamental assumpti
 
 The other rules are essentially the same but there are some implications of the above changes:
 - Broadcast messages from the high latency channel should be routed to other nodes on the network as usual.
-  Usually only `HIGH_LATENCY2` is broadcast.
+  Note that this in reality most systems on a high latency network **only** send `HIGH_LATENCY2`.
 - Addressed messages should be sent over the high latency channel (in both directions) in accordance with the normal routing rules.
   In practice the lack of `HEARTBEAT` means that addressed messages are unlikely to arrive, and hence be sent.
 
@@ -33,12 +33,12 @@ Message | Description
 
 Command | Description
 -- | --
-<span id="MAV_CMD_CONTROL_HIGH_LATENCY"></span>[MAV_CMD_CONTROL_HIGH_LATENCY](../messages/common.md#MAV_CMD_CONTROL_HIGH_LATENCY) | Command to start/stop transmitting high latency telemetry (`HIGH_LATENCY2`).
+<a id="MAV_CMD_CONTROL_HIGH_LATENCY"></a>[MAV_CMD_CONTROL_HIGH_LATENCY](../messages/common.md#MAV_CMD_CONTROL_HIGH_LATENCY) | Command to start/stop transmitting high latency telemetry (`HIGH_LATENCY2`).
 
 
 Enum | Description
 -- | --
-<span id="HL_FAILURE_FLAG"></span>[HL_FAILURE_FLAG](../messages/common.md#HL_FAILURE_FLAG) | Flags to report failure cases over the high latency telemetry.
+<a id="HL_FAILURE_FLAG"></a>[HL_FAILURE_FLAG](../messages/common.md#HL_FAILURE_FLAG) | Flags to report failure cases over the high latency telemetry.
 
 
 ## Sequences

--- a/en/services/high_latency.md
+++ b/en/services/high_latency.md
@@ -5,6 +5,24 @@ Generally the cost and latency means that high-latency links are only used when 
 
 The protocol provides a heartbeat-like message ([HIGH_LATENCY2](#HIGH_LATENCY2)) for transmitting just the most important telemetry at low rate, and a command ([MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY)) for enabling/disabling the high latency link when needed (i.e. when no lower-latency link is available).
 
+## Heartbeat/Routing
+
+High latency links are expensive.
+In order to reduce traffic to the bare minimum, some of the fundamental assumptions of MAVLink are explicitly broken:
+- [HEARTBEAT](../messages/common.md#HEARTBEAT) messages are not emitted on the channel (either by the autopilot or GCS).
+
+  > **Note** The heartbeat is used to build MAVLInk routing tables between channels.
+    Commands addressed specifically to the high latency component may not be routed from another channel (i.e. you can connect to the component from a GCS directly, but not via a MAVLink router).
+- Broadcast messages from the network should not be automatically sent over the high latency channel.
+
+The other rules are essentially the same but there are some implications of the above changes:
+- Broadcast messages from the high latency channel should be routed to other nodes on the network as usual.
+  Usually only `HIGH_LATENCY2` is broadcast.
+- Addressed messages should be sent over the high latency channel (in both directions) in accordance with the normal routing rules.
+  In practice the lack of `HEARTBEAT` means that addressed messages are unlikely to arrive, and hence be sent.
+
+The implication is that while all components on a MAVLink network will get [HIGH_LATENCY2](#HIGH_LATENCY2) updates, only the directly connected GCS (or other component) will be able to command the vehicle.
+
 
 ## Message/Enum Summary
 


### PR DESCRIPTION
Questions came up as a result of a new implementation of latency protocol (MAVProxy) that were unanswered/unclear in current doc. 

What this says is.
- `HEARTBEAT` is not sent over low latency links.
- `HIGHLATENCY2` is not a heartbeat.
- `Broadcast messages from network are not sent over the high latency link.

The HEARTBEAT is what builds routing tables. What this implies is that everything on the the network with get HIGHLATENCY2 info but only the connected GCS will be able to command the vehicle. If we want other things to be able to do so, then we would have to update the routing docs (and routers) to say that HIGHLATENCY2 should also be used to build routing. 

As an aside, there is a possibility that HIGHLATENCY2 should be updated to include a base mode to allow it to be used on systems that require arming and where the mode is relevant. That would require further updates.

@DonLakeFlyer @peterbarker can you please sanity check?
