### PR TITLE
Added a note about deleting images with MAV_CMD_DELETE_IMAGE

### DIFF
--- a/en/services/camera.md
+++ b/en/services/camera.md
@@ -216,6 +216,7 @@ Individual entries can be requested using [MAV_CMD_REQUEST_MESSAGE](../messages/
 
 The camera image log iterates "forever" (but may be explicitly reset using [MAV_CMD_STORAGE_FORMAT.param3=1](../messages/common.md#MAV_CMD_STORAGE_FORMAT)).
 
+Individual images can be deleted from the camera image log using [MAV_CMD_DELETE_IMAGE] command where `param1="the index of the image to delete"`
 
 ### Video Capture
 


### PR DESCRIPTION
A new command MAV_CMD_DELETE_IMAGE was added to allow deleting the image from the camera image log so that the ground and the vehicle can be kept in sync.
Related PR: https://github.com/mavlink/mavlink/pull/1647