### PR TITLE
Update High Latency service details

### DIFF
--- a/en/services/high_latency.md
+++ b/en/services/high_latency.md
@@ -52,25 +52,32 @@ Enum | Description
 
 ## Sequences
 
-A GCS will typically have one or more (low latency) links that are used for vehicle communications.
-Separate to this are any high latency links.
-The high latency links may be active simultaneous to the low latency links during handover operations.
+A GCS should only upload/download missions, geofences, rally points, and parameters when connected over a _low latency_ link.
+Generally a vehicle is connected to the GCS via a low latency link for initial synchronisation of parameters etc., and will reconnect whenever the low latency vehicle is available.
+When the link is not available it will switch to the high latency link and primarily just monitor the high latency telementry. 
 
-A typical flight sequence will look like:
-- Vehicle starts up on the ground with low latency links active
-- Ground station(s) download, check and sync all [mission protocol](../services/mission.md) items and [parameter protocol](../services/parameter.md) items over low latency link
-- Vehicle starts mission
-- Whilst still in range of low latency link, enable high latency link and confirm transmission of messages over high latency link.
-- Vehicle moves out of range of low latency link.
+A typical flight sequence might therefore look like:
+- Vehicle is started and connects to ground station over low latency link (e.g. USB cable, Telemetry radio).
+- Ground station(s) download, check and sync all [mission protocol](../services/mission.md) items and [parameter protocol](../services/parameter.md) items over the low latency link
+- Vehicle starts mission.
+- Ground station detects when low latency link is lost/available and enables/disables the high latency link appropriately.
+  - While low latency link is active the mission and parameter protocols can be used. 
+  - While high latency link is active the vehicle provide telemetry updates but parameters and missions should not be updated.
 
-The reverse occurs at the end of a mission.
-
-The GCS and autopilot should be able to work with a mixed regime of low and high latency links. Any [command protocol](../services/command.md) messages should be sent over all available links.
-
-If used, the high latency link should be enabled (MAV_CMD_CONTROL_HIGH_LATENCY message) over the low latency link prior to loss of coverage. This ensures no break in telemetry. (i.e sending the MAV_CMD_CONTROL_HIGH_LATENCY on the high latency link _after_ loss of the low latency link may mean a wait of several 10's of seconds before the first HIGH_LATENCY2 message appears at the GCS).
+When the low latency link is lost, the GCS sends [MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY) to the vehicle over the high latency channel to turn the high latency link on on (causing the vehicle to start emitting [HIGH_LATENCY2](#HIGH_LATENCY2) messages).
+When the low latency link is regained the GCS sends [MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY) to stop the vehicle from broadcasting [HIGH_LATENCY2](#HIGH_LATENCY2) messages (usually this would be sent over the low latency link).
 
 The diagram below shows a GCS switching from a higher-latency primary link to a lower latency secondary link when one becomes available, and then back to the higher latency link when the primary link drops out.
-[MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY) is sent to turn the high latency link on and off.
-
 
 [![](https://mermaid.ink/img/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgTm90ZSBvdmVyIEdDUyxEcm9uZTogRHJvbmUgY29ubmVjdGVkIG92ZXIgSEwgY29ubmVjdGlvblxuICAgIERyb25lLT4-R0NTOiBISUdIX0xBVEVOQ1kyXG4gICAgRHJvbmUtPj5HQ1M6IC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IExvd2VyIGxhdGVuY3kgY29ubmVjdGlvbiBhdmFpbGFibGUuIFN0b3AgSEwgY29ubmVjdGlvbi5cbiAgICBHQ1MtPj5Ecm9uZTogTUFWX0NNRF9DT05UUk9MX0hJR0hfTEFURU5DWShwYXJhbTE9MClcbiAgICBEcm9uZS0-PkdDUzogTm9ybWFsIGxhdGVuY3kgbWVzc2FnZXMgb3ZlciBuZXcgY2hhbm5lbC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IFByaW1hcnkgY29ubmVjdGlvbiBkcm9wcyBvdXQuIFN0YXJ0IEhMIGNvbm5lY3Rpb24uXG4gICAgR0NTLT4-RHJvbmU6IE1BVl9DTURfQ09OVFJPTF9ISUdIX0xBVEVOQ1kocGFyYW0xPTEpXG4gICAgRHJvbmUtPj5HQ1M6IEhJR0hfTEFURU5DWTIiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgTm90ZSBvdmVyIEdDUyxEcm9uZTogRHJvbmUgY29ubmVjdGVkIG92ZXIgSEwgY29ubmVjdGlvblxuICAgIERyb25lLT4-R0NTOiBISUdIX0xBVEVOQ1kyXG4gICAgRHJvbmUtPj5HQ1M6IC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IExvd2VyIGxhdGVuY3kgY29ubmVjdGlvbiBhdmFpbGFibGUuIFN0b3AgSEwgY29ubmVjdGlvbi5cbiAgICBHQ1MtPj5Ecm9uZTogTUFWX0NNRF9DT05UUk9MX0hJR0hfTEFURU5DWShwYXJhbTE9MClcbiAgICBEcm9uZS0-PkdDUzogTm9ybWFsIGxhdGVuY3kgbWVzc2FnZXMgb3ZlciBuZXcgY2hhbm5lbC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IFByaW1hcnkgY29ubmVjdGlvbiBkcm9wcyBvdXQuIFN0YXJ0IEhMIGNvbm5lY3Rpb24uXG4gICAgR0NTLT4-RHJvbmU6IE1BVl9DTURfQ09OVFJPTF9ISUdIX0xBVEVOQ1kocGFyYW0xPTEpXG4gICAgRHJvbmUtPj5HQ1M6IEhJR0hfTEFURU5DWTIiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)
+
+The sequence above assumes that high latency links are only enabled _after_ the GCS has lost low latency links.
+A system may also support a handover model, where the high latency link is established before the low latency link is dropped (i.e. the high latency link may be enabled by sending `MAV_CMD_CONTROL_HIGH_LATENCY` over the low latency link prior to loss of coverage).
+
+This approach ensures no break in telemetry; sending the MAV_CMD_CONTROL_HIGH_LATENCY on the high latency link _after_ loss of the low latency link may mean a wait of several 10's of seconds before the first HIGH_LATENCY2 message appears at the GCS.
+
+If using a handover model:
+- The GCS and autopilot should be able to work with a mixed regime of low and high latency links.
+- Any [command protocol](../services/command.md) messages should be sent over all available links.
+
+

--- a/en/services/high_latency.md
+++ b/en/services/high_latency.md
@@ -1,7 +1,7 @@
 # High Latency Protocol
 
-High Latency (HL) links, for example made using the [Iridium Satellite network](Iridium Satellite), provide global connectivity, albeit with significant message latency (> 1 second) and high cost-per-message.
-Generally the cost and latency means that high-latency links are only used when there is no lower-latency alternative, and when active the links should only send essential information or commands.
+High Latency (HL) links, for example made using the [Iridium Satellite network](https://www.iridium.com/), provide global connectivity, albeit with significant message latency (> 1 second) and high cost-per-message.
+Generally the cost and latency means that high-latency links are only used when there is no lower-latency alternative, and should only send essential information or commands.
 
 The protocol provides a heartbeat-like message ([HIGH_LATENCY2](#HIGH_LATENCY2)) for transmitting just the most important telemetry at low rate, and a command ([MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY)) for enabling/disabling the HL link when needed (i.e. when no lower-latency link is available).
 
@@ -11,13 +11,12 @@ The GCS should carefully manage what data is sent to/requested from the autopilo
 
 - Ground stations should not upload or download missions, waypoints or geofences on the HL link (i.e. should not use the [mission protocol](../services/mission.md)).
 - Ground stations should not update or synchronise parameters over the HL channel (i.e. using the [parameter protocol](../services/parameter.md)).
-- [HEARTBEAT](../messages/common.md#HEARTBEAT) messages should not be sent over the HL channel.
-  See the section below for more information.
+- [HEARTBEAT](../messages/common.md#HEARTBEAT) messages should not be sent over the HL channel (see the section below for more information).
 
+Typically the initial connection with a GCS is made over a low latency link (often before takeoff), so that the above data can be transferred before switching to the HL link.
 
 ## Heartbeat/Routing
 
-High latency links are expensive.
 In order to reduce traffic to the bare minimum, some of the fundamental assumptions of MAVLink are explicitly broken:
 - [HEARTBEAT](../messages/common.md#HEARTBEAT) messages are not emitted on the channel (either by the autopilot or GCS).
   > **Note** The heartbeat is used to build MAVLink routing tables between channels.
@@ -54,7 +53,7 @@ Enum | Description
 
 A GCS should only upload/download missions, geofences, rally points, and parameters when connected over a _low latency_ link.
 Generally a vehicle is connected to the GCS via a low latency link for initial synchronisation of parameters etc., and will reconnect whenever the low latency vehicle is available.
-When the link is not available it will switch to the high latency link and primarily just monitor the high latency telementry. 
+When the link is not available it will switch to the high latency link and primarily just monitor the high latency telemetry. 
 
 A typical flight sequence might therefore look like:
 - Vehicle is started and connects to ground station over low latency link (e.g. USB cable, Telemetry radio).
@@ -71,13 +70,12 @@ The diagram below shows a GCS switching from a higher-latency primary link to a 
 
 [![](https://mermaid.ink/img/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgTm90ZSBvdmVyIEdDUyxEcm9uZTogRHJvbmUgY29ubmVjdGVkIG92ZXIgSEwgY29ubmVjdGlvblxuICAgIERyb25lLT4-R0NTOiBISUdIX0xBVEVOQ1kyXG4gICAgRHJvbmUtPj5HQ1M6IC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IExvd2VyIGxhdGVuY3kgY29ubmVjdGlvbiBhdmFpbGFibGUuIFN0b3AgSEwgY29ubmVjdGlvbi5cbiAgICBHQ1MtPj5Ecm9uZTogTUFWX0NNRF9DT05UUk9MX0hJR0hfTEFURU5DWShwYXJhbTE9MClcbiAgICBEcm9uZS0-PkdDUzogTm9ybWFsIGxhdGVuY3kgbWVzc2FnZXMgb3ZlciBuZXcgY2hhbm5lbC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IFByaW1hcnkgY29ubmVjdGlvbiBkcm9wcyBvdXQuIFN0YXJ0IEhMIGNvbm5lY3Rpb24uXG4gICAgR0NTLT4-RHJvbmU6IE1BVl9DTURfQ09OVFJPTF9ISUdIX0xBVEVOQ1kocGFyYW0xPTEpXG4gICAgRHJvbmUtPj5HQ1M6IEhJR0hfTEFURU5DWTIiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtO1xuICAgIHBhcnRpY2lwYW50IEdDU1xuICAgIHBhcnRpY2lwYW50IERyb25lXG4gICAgTm90ZSBvdmVyIEdDUyxEcm9uZTogRHJvbmUgY29ubmVjdGVkIG92ZXIgSEwgY29ubmVjdGlvblxuICAgIERyb25lLT4-R0NTOiBISUdIX0xBVEVOQ1kyXG4gICAgRHJvbmUtPj5HQ1M6IC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IExvd2VyIGxhdGVuY3kgY29ubmVjdGlvbiBhdmFpbGFibGUuIFN0b3AgSEwgY29ubmVjdGlvbi5cbiAgICBHQ1MtPj5Ecm9uZTogTUFWX0NNRF9DT05UUk9MX0hJR0hfTEFURU5DWShwYXJhbTE9MClcbiAgICBEcm9uZS0-PkdDUzogTm9ybWFsIGxhdGVuY3kgbWVzc2FnZXMgb3ZlciBuZXcgY2hhbm5lbC4uLlxuICAgIE5vdGUgb3ZlciBHQ1MsRHJvbmU6IFByaW1hcnkgY29ubmVjdGlvbiBkcm9wcyBvdXQuIFN0YXJ0IEhMIGNvbm5lY3Rpb24uXG4gICAgR0NTLT4-RHJvbmU6IE1BVl9DTURfQ09OVFJPTF9ISUdIX0xBVEVOQ1kocGFyYW0xPTEpXG4gICAgRHJvbmUtPj5HQ1M6IEhJR0hfTEFURU5DWTIiLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9LCJ1cGRhdGVFZGl0b3IiOmZhbHNlfQ)
 
-The sequence above assumes that high latency links are only enabled _after_ the GCS has lost low latency links.
-A system may also support a handover model, where the high latency link is established before the low latency link is dropped (i.e. the high latency link may be enabled by sending `MAV_CMD_CONTROL_HIGH_LATENCY` over the low latency link prior to loss of coverage).
 
-This approach ensures no break in telemetry; sending the MAV_CMD_CONTROL_HIGH_LATENCY on the high latency link _after_ loss of the low latency link may mean a wait of several 10's of seconds before the first HIGH_LATENCY2 message appears at the GCS.
+### Explicit Handover
 
-If using a handover model:
-- The GCS and autopilot should be able to work with a mixed regime of low and high latency links.
-- Any [command protocol](../services/command.md) messages should be sent over all available links.
+A ground station may also support a handover model, where the high latency link is established before the low latency link is dropped (i.e. the high latency link may be enabled by sending `MAV_CMD_CONTROL_HIGH_LATENCY` over the low latency link prior to loss of coverage).
 
+This approach allows the GCS to verify that the high latency link is available before losing the low latency connection.
 
+If using this model the GCS and autopilot should be able to work with a mixed regime of low and high latency links.
+Specifically, this means that they should be able to handle the case where the same message is sent over different both channels.

--- a/en/services/high_latency.md
+++ b/en/services/high_latency.md
@@ -1,7 +1,7 @@
 # High Latency Protocol
 
-High latency links (e.g. Iridium Satellite links) provide global connectivity, albeit with significant message latency and high cost-per-message.
-Generally the cost and latency means that high-latency links are only used when there is no lower-latency alternative, and when active the links should only send essential information.
+High latency links (e.g. Iridium Satellite links) provide global connectivity, albeit with significant message latency (> 1 second) and high cost-per-message.
+Generally the cost and latency means that high-latency links are only used when there is no lower-latency alternative, and when active the links should only send essential information or commands.
 
 The protocol provides a heartbeat-like message ([HIGH_LATENCY2](#HIGH_LATENCY2)) for transmitting just the most important telemetry at low rate, and a command ([MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY)) for enabling/disabling the high latency link when needed (i.e. when no lower-latency link is available).
 
@@ -10,18 +10,20 @@ The protocol provides a heartbeat-like message ([HIGH_LATENCY2](#HIGH_LATENCY2))
 High latency links are expensive.
 In order to reduce traffic to the bare minimum, some of the fundamental assumptions of MAVLink are explicitly broken:
 - [HEARTBEAT](../messages/common.md#HEARTBEAT) messages are not emitted on the channel (either by the autopilot or GCS).
-
-  > **Note** The heartbeat is used to build MAVLInk routing tables between channels.
+  > **Note** The heartbeat is used to build MAVLink routing tables between channels.
     Commands addressed specifically to the high latency component may not be routed from another channel (i.e. you can connect to the component from a GCS directly, but not via a MAVLink router).
-- Broadcast messages from the network should not be automatically sent over the high latency channel.
+- Only the [command protocol](../services/command.md) service messages and [HIGH_LATENCY2](#HIGH_LATENCY2) message should be sent over the high latency channel.
+- Ground stations should not send or receive [mission protocol](../services/mission.md) items or [parameter protocol](../services/parameter.md) items over the high latency channel in order to prevent congestion.
 
 The other rules are essentially the same but there are some implications of the above changes:
-- Broadcast messages from the high latency channel should be routed to other nodes on the network as usual.
+- Messages from the high latency channel should be routed to other nodes on the network as usual.
   Note that this in reality most systems on a high latency network **only** send `HIGH_LATENCY2`.
 - Addressed messages should be sent over the high latency channel (in both directions) in accordance with the normal routing rules.
   In practice the lack of `HEARTBEAT` means that addressed messages are unlikely to arrive, and hence be sent.
+- Parameters, waypoints, geofences and rally points will not be downloaded over a high latency channel.
+- The GCS should carefully manage what messages to send to the autopilot, in order to avoid congestion on the high latency link
 
-The implication is that while all components on a MAVLink network will get [HIGH_LATENCY2](#HIGH_LATENCY2) updates, only the directly connected GCS (or other component) will be able to command the vehicle.
+The implication is that while all components on a MAVLink network will get [HIGH_LATENCY2](#HIGH_LATENCY2) updates, only the directly connected GCS (or other component) will be able send [command protocol](../services/command.md) messages to the vehicle.
 
 
 ## Message/Enum Summary
@@ -43,7 +45,20 @@ Enum | Description
 
 ## Sequences
 
-A GCS will typically have one primary link that is used for all vehicle communications, but may also have secondary links that it can switch to if needed (which will then become the primary link).
+A GCS will typically have one or more (low latency) links that are used for vehicle communications. Separate to this are any high latency links. The high latency links may be active simultaneous to the low latency links during handover operations.
+
+A typical flight sequence will look like:
+- Vehicle starts up on the ground with low latency links active
+- Ground station(s) download, check and sync all [mission protocol](../services/mission.md) items and [parameter protocol](../services/parameter.md) items over low latency link
+- Vehicle starts mission
+- Whilst still in range of low latency link, enable high latency link and confirm transmission of messages over high latency link.
+- Vehicle moves out of range of low latency link.
+
+The reverse occurs at the end of a mission.
+
+The GCS and autopilot should be able to work with a mixed regime of low and high latency links. Any [command protocol](../services/command.md) messages should be sent over all available links.
+
+If used, the high latency link should be enabled (MAV_CMD_CONTROL_HIGH_LATENCY message) over the low latency link prior to loss of coverage. This ensures no break in telemetry. (i.e sending the MAV_CMD_CONTROL_HIGH_LATENCY on the high latency link _after_ loss of the low latency link may mean a wait of several 10's of seconds before the first HIGH_LATENCY2 message appears at the GCS).
 
 The diagram below shows a GCS switching from a higher-latency primary link to a lower latency secondary link when one becomes available, and then back to the higher latency link when the primary link drops out.
 [MAV_CMD_CONTROL_HIGH_LATENCY](#MAV_CMD_CONTROL_HIGH_LATENCY) is sent to turn the high latency link on and off.


### PR DESCRIPTION
This PR addresses a few issues I've had whilst implementing the High Latency service on ArduPilot.

For reference, the "high latency" link I've been working with is an Inmarsat SBD, which allows ~60 bytes per second, with a 10-30 second latency.

They are:

A) Allowable messages. Only the bare minimum messages should be sent for basic control and status updates.
-The GCS should only send COMMAND_LONG and HEARTBEAT messages to the autopilot. Requesting params, waypoints, etc will clag up a high latency link fairly quickly.
-Likewise, the autopilot should only send the HIGH_LATENCY2 and any COMMAND_ACK messages to the GCS on the high latency link.

B) Changing between low and high latency links
-Both autopilot and GCS should be able to cope with both low and high latency links being used simultaneously. Users may have their low latency link cut out with little to no warning (out of range, for example). Having to then send a HIGH_LATENCY_CONTROL message and wait for the first HIGH_LATENCY2 message could take 60 seconds or so.
-The autopilot should be capable of transmitting HIGH_LATENCY2 messages on designated high latency links from bootup, if configured to do so (could be a parameter or setting)

@hamishwillee 