### PR TITLE
Long running commands - receiving same command is request for progress update

### DIFF
--- a/en/services/command.md
+++ b/en/services/command.md
@@ -84,6 +84,9 @@ The drone should cancel the operation and complete the sequence by sending `COMM
 - If cancellation is not supported the drone can just continue to send progress updates until completion.
 - If the sequence has already completed (or is idle) the cancel command should be ignored.
 
+If the _same_ long running command is recieved while the command is in progress it is treated as a request for a progress update. 
+The target system should just respond with `MAV_RESULT_IN_PROGRESS` and the progress.
+
 > **Note** If another command is received while handling a command (long running or otherwise) the new command should be rejected with `MAV_RESULT_TEMPORARILY_REJECTED`.
   What this means is that to restart an operation (i.e. with new parameters) it must first be cancelled.
   

--- a/en/services/command.md
+++ b/en/services/command.md
@@ -84,7 +84,7 @@ The drone should cancel the operation and complete the sequence by sending `COMM
 - If cancellation is not supported the drone can just continue to send progress updates until completion.
 - If the sequence has already completed (or is idle) the cancel command should be ignored.
 
-If the _same_ long running command is recieved while the command is in progress it is treated as a request for a progress update. 
+If the _same_ long running command is received while the command is in progress it is treated as a request for a progress update. 
 The target system should just respond with `MAV_RESULT_IN_PROGRESS` and the progress.
 
 > **Note** If another command is received while handling a command (long running or otherwise) the new command should be rejected with `MAV_RESULT_TEMPORARILY_REJECTED`.


### PR DESCRIPTION
This came up here: https://github.com/mavlink/qgroundcontrol/pull/9904#issuecomment-965810396

Essentially QGC is polling for progress updates rather than waiting for them from AutoTune. That's a reasonable approach, and it makes sense that the protocol should act in this way - so this explicitly specifies the implied behaviour.

Note, it is a bit scary, in that if you poll like this, you could kick off another autotune if you do it too late.