### PR TITLE
Using C library - add info on build warnings

### DIFF
--- a/en/mavgen_c/README.md
+++ b/en/mavgen_c/README.md
@@ -19,19 +19,6 @@ The libraries can be placed/generated anywhere in your project tree.
 The example below shows them located in: **generated/include/mavlink/v2.0/**.
 
 
-## Upgrading Library from MAVLink 1
-
-The *MAVLink 1* pre-built library [mavlink/c_library_v1](https://github.com/mavlink/c_library_v1) can be upgraded by simply dropping in the *MAVLink 2* library from Github: [mavlink/c_library_v2](https://github.com/mavlink/c_library_v2).
-
-The *MAVLink 2* C library offers the same range of APIs as was offered by *MAVLink 1*. 
-
-> **Note** The major change from an API perspective is that you don't need to provide a message CRC table any more, or message length table.
-  These have been folded into a single packed table, replacing the old table which was indexed by `msgId`.
-  That was necessary to cope with the much larger 24 bit namespace of message IDs.
-
-*MAVLink 2* usage is covered in the following sections (this includes [Working with MAVLink 1](#mavlink_1) which explains how you can communicate with both *MAVLink 2* and *MAVLink 1* (only) libraries.
-
-
 ## Adding Libraries
 
 To use MAVLink in your C project, include the **mavlink.h** header file for your dialect:
@@ -60,6 +47,29 @@ mavlink_system_t mavlink_system = {
 }; 
 ```
 
+### Build Warnings
+
+Building the headers may result in warnings like:
+```
+mavlink/common/../mavlink_helpers.h:86:24: warning: taking address of packed member of ‘__mavlink_message’ may result in an unaligned pointer value [-Waddress-of-packed-member]
+   86 |  crc_accumulate_buffer(&msg->checksum, _MAV_PAYLOAD(msg), msg->len);
+```
+
+These warnings are commonly suppressed/ignored.
+For example, you can do this in CMake using `target_compile_options(mavlink_c INTERFACE -Wno-address-of-packed-member -Wno-cast-align)`
+
+
+## Upgrading Library from MAVLink 1
+
+The *MAVLink 1* pre-built library [mavlink/c_library_v1](https://github.com/mavlink/c_library_v1) can be upgraded by simply dropping in the *MAVLink 2* library from Github: [mavlink/c_library_v2](https://github.com/mavlink/c_library_v2).
+
+The *MAVLink 2* C library offers the same range of APIs as was offered by *MAVLink 1*. 
+
+> **Note** The major change from an API perspective is that you don't need to provide a message CRC table any more, or message length table.
+  These have been folded into a single packed table, replacing the old table which was indexed by `msgId`.
+  That was necessary to cope with the much larger 24 bit namespace of message IDs.
+
+*MAVLink 2* usage is covered in the following sections (this includes [Working with MAVLink 1](#mavlink_1) which explains how you can communicate with both *MAVLink 2* and *MAVLink 1* (only) libraries.
 
 ## Multiple Streams ("channels") {#channels}
 


### PR DESCRIPTION
https://github.com/mavlink/mavlink/issues/1764 reported build warnings, and asked if we should care.

This PR adds a note that they can be ignored (and how). It also reorders the How to use section slightly so upgrading from MAVLink 1 is now after the "Adding libraries" - most people will already have upgraded.