### PR TITLE
FTP - clarify MAVFTP maps closely to FTP

### DIFF
--- a/en/services/ftp.md
+++ b/en/services/ftp.md
@@ -1,7 +1,10 @@
 # File Transfer Protocol (FTP)
 
-The FTP Protocol enables an FTP-like file transfer protocol over MAVLink.
+The File Transfer Protocol (FTP) enables file transfer over MAVLink.
 It supports common FTP operations like: reading, truncating, writing, removing and creating files, listing and removing directories.
+
+> **Note** MAVLink FTP implementation closely follows the design of the original internet [FTP protocol](https://en.wikipedia.org/wiki/File_Transfer_Protocol) in terms of the message structure, sequences, and the supported opcodes/operations.
+> Developers can read the Internet protocol RFCs to understand MAVLink FTP.
 
 The protocol follows a client-server pattern, where all commands are sent by the GCS (client), 
 and the Drone (server) responds either with an ACK containing the requested information, or a NAK containing an error. 


### PR DESCRIPTION
As discussed in [dev call](https://github.com/mavlink/mavlink/wiki/20220216-Dev-Meeting), good to make it clear that we didn't invent FTP, and that MAVFTP is a close copy of the original protocol. 

