### PR TITLE
Doc Update: changes for Java mavgen

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -45,7 +45,7 @@ C++11   | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &ch
 Python (2.7+, 3.3+) | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; | Python bindings. Library also available on PyPi: [pymavlink](https://pypi.org/project/pymavlink/).
 C#      | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; |  | | 
 Objective C | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | | | 
-Java    | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; | Use dronefleet, since dronefleet is fully implemented | 
+Java    | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; |  | Dronefleet offers a more idiomatic generated library | 
 JavaScript (Stable) | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &cross; | Old mavgen JavaScript binding (has known bugs and no test suite). 
 JavaScript (NextGen) | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; | New mavgen JavaScript library. Full test suite, resulting library produces binary compatible output compared to C bindings. Slightly incompatible with previous version, but not hard to migrate.
 TypeScript/JavaScript | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &cross; | TypeScript classes which can be used with [node-mavlink](https://github.com/ifrunistuttgart/node-mavlink).

--- a/en/README.md
+++ b/en/README.md
@@ -45,7 +45,7 @@ C++11   | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &ch
 Python (2.7+, 3.3+) | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; | Python bindings. Library also available on PyPi: [pymavlink](https://pypi.org/project/pymavlink/).
 C#      | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; |  | | 
 Objective C | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | | | 
-Java    | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | | | | 
+Java    | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; | Use dronefleet, since dronefleet is fully implemented | 
 JavaScript (Stable) | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &cross; | Old mavgen JavaScript binding (has known bugs and no test suite). 
 JavaScript (NextGen) | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &check; | New mavgen JavaScript library. Full test suite, resulting library produces binary compatible output compared to C bindings. Slightly incompatible with previous version, but not hard to migrate.
 TypeScript/JavaScript | [mavgen](getting_started/generate_libraries.md#mavgen) | &check; | &check; | &cross; | TypeScript classes which can be used with [node-mavlink](https://github.com/ifrunistuttgart/node-mavlink).


### PR DESCRIPTION
Updated the MAVLink Project Generators/Languages Table for java support for MAVLink 2 and signing

In the MAVLink Project Generators/Languages table, at https://mavlink.io/en/#mavlink-project-generatorslanguages, for Java the check/tick is not there for MAVLink 2 and Signing columns, but mavgen can create MAVLink 2 libraries for Java

The MAVLink 2 and Signing columns should be checked for Java and in Notes column we can state to use dronefleet, since dronefleet is fully implemented

Resolving Issue: https://github.com/mavlink/mavlink-devguide/issues/457