### PR TITLE
Pymavlink updates/restructure

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -14,7 +14,11 @@
     * [Examples](mavgen_c/examples.md)
       * [UART Interface (C)](mavgen_c/example_c_uart.md)
       * [UDP Example (C)](mavgen_c/example_c_udp.md)
-  * [Python (mavgen)](mavgen_python/README.md)
+  * [Pymvalink (Python-mavgen)](mavgen_python/README.md)
+    * [How to Request Messages/Set Message Rates](mavgen_python/howto_requestmessages.md)
+    * [Message Signing](mavgen_python/message_signing.md)
+    * [Examples](mavgen_python/examples.md)
+
 * [Guide](guide/README.md)
   * [MAVLink Versions](guide/mavlink_version.md)
   * [MAVLink 2](guide/mavlink_2.md)

--- a/en/mavgen_python/README.md
+++ b/en/mavgen_python/README.md
@@ -294,17 +294,14 @@ If needed, you can query `MAVLink_message` for information about the signature, 
 #### Requesting Specific Messages {#specific_messages}
 
 A remote system will typically stream a *default* set of messages to a connected GCS, camera or other system.
-This default set may be hard coded, and is necessarily limited to reduce traffic on the channel.
+This set may be hard coded, and is necessarily limited to reduce traffic on the channel.
 
-Typically a system can also request that additional information be provided by sending the [REQUEST_DATA_STREAM](../messages/common.md#REQUEST_DATA_STREAM) message, specifying the required stream(s) ([MAV_DATA_STREAM](../messages/common.md#MAV_DATA_STREAM)) and rate. 
+A system can request that additional messages are sent as a stream, or change the rate at which existing streamed messages are sent, using the [MAV_CMD_SET_MESSAGE_INTERVAL](../messages/common.md#MAV_CMD_SET_MESSAGE_INTERVAL) command.
+This can be sent in either a [COMMAND_LONG](../messages/common.md#COMMAND_LONG) or [COMMAND_INT](../messages/common.md#COMMAND_INT), if supported by the flight stack.
 
-The message is sent using `request_data_stream_send()` (below `arg.rate` would be the desired transmission rate)
+For more information see [How to request messages](../mavgen_python/howto_requestmessages.md)
 
-```python
-# Request all data streams
-the_connection.mav.request_data_stream_send(the_connection.target_system, the_connection.target_component,
-                                        mavutil.mavlink.MAV_DATA_STREAM_ALL, args.rate, 1)
-```
+
 
 ### Publishing a Heartbeat {#heartbeat}
 
@@ -360,107 +357,12 @@ Pymavlink supports [Message Signing](../guide/message_signing.md) (authenticatio
 The Pymavlink library already implements almost all of the expected behaviour for signing messages.
 All you need to do is provide a secret key and initial timestamp, optionally specify whether or not outgoing messages should be signed, a link id, and a callback for determining which unsigned messages (if any) will be accepted.
 
-The way you do this depends on whether you are using **mavutil** to manage the connection or using a `MAVLink` object directly.
-
-> **Note** While not covered in this topic, you should also write code to:
-> * Save and load the key and last-timestamp from permanent storage
-> * Implement a mechanism to create and share the key. For more information see [Message Signing > Secret Key Management](../guide/message_signing.md#secret_key).
-
-
-#### Signing using MAVLink Class
-
-If you are using the `MAVLink` class directly, you can use the **`MAVLink.signing`** attribute to access a `MAVLinkSigning` object and set the required attributes.
-
-The [example/mavtest.py](https://github.com/ArduPilot/pymavlink/blob/master/examples/mavtest.py) script shows how to do this using an arbitrary secret key:
-```python
-# Create a MAVLink instance (in this case on a file object "f")
-mav = mavlink.MAVLink(f)
-
-if signing:
-    mav.signing.secret_key = chr(42)*32
-    mav.signing.link_id = 0
-    mav.signing.timestamp = 0
-    mav.signing.sign_outgoing = True
-```
-
-> **Note** The `MAVLink` class does not ensure that your `link_id` or *initial* `timestamp` are appropriate.
-  The initial timestamp should be based on current system time. 
-  For more information see [Message Signing](../guide/message_signing.md#timestamp).
-
-
-#### Signing using mavutil
-
-If you are using **mavutil** to manage the connection then you can set up/disable signing using the methods shown below:
-
-```python
-#Setup signing
-def setup_signing(self, secret_key, sign_outgoing=True, allow_unsigned_callback=None, initial_timestamp=None, link_id=None)
-
-# Disable signing (clear secret key and all the other settings specified with setup_signing)
-def disable_signing(self):
-```
-
-The `setup_signing()` method sets up the `MAVLink` object owned by the connection and provides some additional code:
-- If `link_id` is not specified then internally the value is iterated.
-- If `initial_timestamp` is not set then an appropriate value for current time is populated from the underlying OS.
-
-
-#### Using allow_unsigned_callback
-
-[Message Signing > Accepting Unsigned Packets](../guide/message_signing.md#accepting_unsigned_packets) and [Accepting Incorrectly Signed Packets](../guide/message_signing.md#accepting_incorrectly_signed_packets) specify that a message signing implementation should provide mechanisms such that library users can choose to conditionally accept unsigned or incorrectly signed packets.
-
-Pymavlink provides the optional `allow_unsigned_callback()` callback for this purpose.
-The prototype for this function is:
-
-```python
-bool allow_unsigned_callback(self, msgId)
-```
-
-If set as part of the signing configuration then this function will be called on any unsigned packet (including all *MAVLink 1* packets) or any packet where the signature is incorrect.
-If the function returns `False` the message will be dropped (otherwise it will be handled as though signed). 
-
-The rules for what unsigned packets should be accepted is implementation specific, but it is suggested the implementations always accept `RADIO_STATUS` packets for feedback from 3DR radios (which don't support signing)
-
-For example:
-
-```python
-# Assuming you already have a connection set up
-the_connection = mavutil.mavlink_connection(...)
-
-# Create a callback to specify the messages to accept
-def my_allow_unsigned_callback(self,msgId):
-    #Allow radio status messages
-    if msgId==mavutil.mavlink.MAVLINK_MSG_ID_RADIO_STATUS:
-        return True
-    return False
-
-# Pass the callback  to the connection (here we also pass an arbitrary secret key)
-secret_key = chr(42)*32
-the_connection.setup_signing(secret_key, sign_outgoing=True, allow_unsigned_callback=my_allow_unsigned_callback)
-```
-
-<!--  NOT SURE WHAT WE NEED TO SAY HERE. TEMPTED TO MOVE THIS SECTION INTO PARENT DOC about MESSAGE SIGNING 
-#### Handling Link IDs {#handling_link_ids}
-
-The purpose of the `link_id` field in the *MAVLink 2* signing structure is to prevent cross-channel replay attacks. 
-Without the `link_id` an attacker could record a packet (such as a disarm request) on one channel, then play it back on a different channel.
-
-The intention with the link IDs is that each channel of communication between an autopilot and a GCS uses a different link ID. 
-There is no requirement that the same link ID be used in both directions however.
---> 
+For more information see [Message Signing (Pymavlink)](../mavgen_python/message_signing.md).
 
 
 ## Examples
 
-There are a number of useful examples and complete systems based on pymavlink:
-- The [pymavlink submodule](https://github.com/ArduPilot/pymavlink/tree/master/examples) contains a number of simple examples.
-- [MAVProxy](http://ardupilot.github.io/MAVProxy/html/development/index.html) is a command line, console based UAV ground station software package for MAVLink based systems.
-  - It demonstrates most of the features of using the MAVLink module. 
-  - The source code can be found here: https://github.com/ArduPilot/MAVProxy
-- [DroneKit-Python](http://python.dronekit.io/) is a developer API that builds on Pymavlink.
-  - It implements a simpler high-level API for accessing vehicle information and also implementations of some of the [MAVLink sub-protocols/microservices](../services/README.md) (eg. mission protocol).
-  - The source code can be found here: https://github.com/dronekit/dronekit-python
-
+See [Examples (pymavlink)](../mavgen_python/examples.md)
   
 ## Support
 

--- a/en/mavgen_python/_examples/setratecommandspecific.py
+++ b/en/mavgen_python/_examples/setratecommandspecific.py
@@ -1,0 +1,39 @@
+"""
+Example: Set that a message is streamed at particular rate
+"""
+
+from pymavlink import mavutil
+
+# Start a connection listening on a UDP port
+connection = mavutil.mavlink_connection('udpin:localhost:14551')
+
+# Wait for the first heartbeat to set the system and component ID of remote system for the link
+connection.wait_heartbeat()
+print("Heartbeat from system (system %u component %u)" % (connection.target_system, connection.target_component))
+
+# Define command_long_encode message to send MAV_CMD_SET_MESSAGE_INTERVAL command
+# param1: MAVLINK_MSG_ID_BATTERY_STATUS (message to stream)
+# param2: 1000000 (Stream interval in microseconds)
+message = connection.mav.command_long_encode(
+        connection.target_system,  # Target system ID
+        connection.target_component,  # Target component ID
+        mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL,  # ID of command to send
+        0,  # Confirmation
+        mavutil.mavlink.MAVLINK_MSG_ID_BATTERY_STATUS,  # param1: Message ID to be streamed
+        1000000, # param2: Interval in microseconds
+        0,       # param3 (unused)
+        0,       # param4 (unused)
+        0,       # param5 (unused)
+        0,       # param5 (unused)
+        0        # param6 (unused)
+        )
+
+# Send the COMMAND_LONG     
+connection.mav.send(message)
+
+# Wait for a response (blocking) to the MAV_CMD_SET_MESSAGE_INTERVAL command and print result
+response = connection.recv_match(type='COMMAND_ACK', blocking=True)
+if response and response.command == mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL and response.result == mavutil.mavlink.MAV_RESULT_ACCEPTED:
+    print("Command accepted")
+else:
+    print("Command failed")

--- a/en/mavgen_python/examples.md
+++ b/en/mavgen_python/examples.md
@@ -1,0 +1,13 @@
+## Examples (Pymavlink)
+
+Other examples:
+
+- [ArduPilot/pymavlink/examples](https://github.com/ArduPilot/pymavlink/tree/master/examples) - The Pymvalink submodule contains a number of simple examples.
+- [ArduSub Pymavlink Docs](https://www.ardusub.com/developers/pymavlink.html) - A number of useful examples, which use ArduSub and MAVProxy
+
+
+Complex examples:
+
+- [MAVProxy](http://ardupilot.github.io/MAVProxy/html/development/index.html) is a command line, console based UAV ground station software package for MAVLink based systems built on Pymavlink.
+  - It demonstrates most of the features of using the MAVLink module. 
+  - The source code can be found here: https://github.com/ArduPilot/MAVProxy

--- a/en/mavgen_python/howto_requestmessages.md
+++ b/en/mavgen_python/howto_requestmessages.md
@@ -1,0 +1,55 @@
+#### How to Request & Stream Messages
+
+A remote system will typically stream a *default* set of messages to a connected GCS, camera or other system.
+This default set may be hard coded, and is necessarily limited to reduce traffic on the channel.
+
+A system can request that additional messages are sent as a stream, or change the rate at which existing streamed messages are sent, using the [MAV_CMD_SET_MESSAGE_INTERVAL](../messages/common.md#MAV_CMD_SET_MESSAGE_INTERVAL) command.
+A single instance of a message can be requested by sending [MAV_CMD_REQUEST_MESSAGE](../messages/common.md#MAV_CMD_REQUEST_MESSAGE).
+
+The example below shows how you can request the [BATTERY_STATUS](../messages/common.md#BATTERY_STATUS) message is streamed at the rate of 1Hz, by sending `MAV_CMD_SET_MESSAGE_INTERVAL` in a [COMMAND_LONG](../messages/common.md#COMMAND_LONG).
+Because this is a command, we then wait for a `COMMAND_ACK` to be recieved with the matching command id, and then display the result.
+Note that you could equally well send the command in a [COMMAND_INT](../messages/common.md#COMMAND_INT), if supported by the flight stack.
+
+```python
+"""
+Example: Set that a message is streamed at particular rate
+"""
+
+from pymavlink import mavutil
+
+# Start a connection listening on a UDP port
+connection = mavutil.mavlink_connection('udpin:localhost:14551')
+
+# Wait for the first heartbeat to set the system and component ID of remote system for the link
+connection.wait_heartbeat()
+print("Heartbeat from system (system %u component %u)" % (connection.target_system, connection.target_component))
+
+# Define command_long_encode message to send MAV_CMD_SET_MESSAGE_INTERVAL command
+# param1: MAVLINK_MSG_ID_BATTERY_STATUS (message to stream)
+# param2: 1000000 (Stream interval in microseconds)
+message = connection.mav.command_long_encode(
+        connection.target_system,  # Target system ID
+        connection.target_component,  # Target component ID
+        mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL,  # ID of command to send
+        0,  # Confirmation
+        mavutil.mavlink.MAVLINK_MSG_ID_BATTERY_STATUS,  # param1: Message ID to be streamed
+        1000000, # param2: Interval in microseconds
+        0,       # param3 (unused)
+        0,       # param4 (unused)
+        0,       # param5 (unused)
+        0,       # param5 (unused)
+        0        # param6 (unused)
+        )
+
+# Send the COMMAND_LONG     
+connection.mav.send(message)
+
+# Wait for a response (blocking) to the MAV_CMD_SET_MESSAGE_INTERVAL command and print result
+response = connection.recv_match(type='COMMAND_ACK', blocking=True)
+if response and response.command == mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL and response.result == mavutil.mavlink.MAV_RESULT_ACCEPTED:
+    print("Command accepted")
+else:
+    print("Command failed")
+```
+
+

--- a/en/mavgen_python/message_signing.md
+++ b/en/mavgen_python/message_signing.md
@@ -1,0 +1,95 @@
+## Message Signing (Pymavlink)
+
+Pymavlink supports [Message Signing](../guide/message_signing.md) (authentication) when using [MAVLink 2](../guide/mavlink_2.md).
+
+The Pymavlink library already implements almost all of the expected behaviour for signing messages.
+All you need to do is provide a secret key and initial timestamp, optionally specify whether or not outgoing messages should be signed, a link id, and a callback for determining which unsigned messages (if any) will be accepted.
+
+The way you do this depends on whether you are using **mavutil** to manage the connection or using a `MAVLink` object directly.
+
+> **Note** While not covered in this topic, you should also write code to:
+> * Save and load the key and last-timestamp from permanent storage
+> * Implement a mechanism to create and share the key. For more information see [Message Signing > Secret Key Management](../guide/message_signing.md#secret_key).
+
+
+#### Signing using MAVLink Class
+
+If you are using the `MAVLink` class directly, you can use the **`MAVLink.signing`** attribute to access a `MAVLinkSigning` object and set the required attributes.
+
+The [example/mavtest.py](https://github.com/ArduPilot/pymavlink/blob/master/examples/mavtest.py) script shows how to do this using an arbitrary secret key:
+```python
+# Create a MAVLink instance (in this case on a file object "f")
+mav = mavlink.MAVLink(f)
+
+if signing:
+    mav.signing.secret_key = chr(42)*32
+    mav.signing.link_id = 0
+    mav.signing.timestamp = 0
+    mav.signing.sign_outgoing = True
+```
+
+> **Note** The `MAVLink` class does not ensure that your `link_id` or *initial* `timestamp` are appropriate.
+  The initial timestamp should be based on current system time. 
+  For more information see [Message Signing](../guide/message_signing.md#timestamp).
+
+
+#### Signing using mavutil
+
+If you are using **mavutil** to manage the connection then you can set up/disable signing using the methods shown below:
+
+```python
+#Setup signing
+def setup_signing(self, secret_key, sign_outgoing=True, allow_unsigned_callback=None, initial_timestamp=None, link_id=None)
+
+# Disable signing (clear secret key and all the other settings specified with setup_signing)
+def disable_signing(self):
+```
+
+The `setup_signing()` method sets up the `MAVLink` object owned by the connection and provides some additional code:
+- If `link_id` is not specified then internally the value is iterated.
+- If `initial_timestamp` is not set then an appropriate value for current time is populated from the underlying OS.
+
+
+#### Using allow_unsigned_callback
+
+[Message Signing > Accepting Unsigned Packets](../guide/message_signing.md#accepting_unsigned_packets) and [Accepting Incorrectly Signed Packets](../guide/message_signing.md#accepting_incorrectly_signed_packets) specify that a message signing implementation should provide mechanisms such that library users can choose to conditionally accept unsigned or incorrectly signed packets.
+
+Pymavlink provides the optional `allow_unsigned_callback()` callback for this purpose.
+The prototype for this function is:
+
+```python
+bool allow_unsigned_callback(self, msgId)
+```
+
+If set as part of the signing configuration then this function will be called on any unsigned packet (including all *MAVLink 1* packets) or any packet where the signature is incorrect.
+If the function returns `False` the message will be dropped (otherwise it will be handled as though signed). 
+
+The rules for what unsigned packets should be accepted is implementation specific, but it is suggested the implementations always accept `RADIO_STATUS` packets for feedback from 3DR radios (which don't support signing)
+
+For example:
+
+```python
+# Assuming you already have a connection set up
+the_connection = mavutil.mavlink_connection(...)
+
+# Create a callback to specify the messages to accept
+def my_allow_unsigned_callback(self,msgId):
+    #Allow radio status messages
+    if msgId==mavutil.mavlink.MAVLINK_MSG_ID_RADIO_STATUS:
+        return True
+    return False
+
+# Pass the callback  to the connection (here we also pass an arbitrary secret key)
+secret_key = chr(42)*32
+the_connection.setup_signing(secret_key, sign_outgoing=True, allow_unsigned_callback=my_allow_unsigned_callback)
+```
+
+<!--  NOT SURE WHAT WE NEED TO SAY HERE. TEMPTED TO MOVE THIS SECTION INTO PARENT DOC about MESSAGE SIGNING 
+#### Handling Link IDs {#handling_link_ids}
+
+The purpose of the `link_id` field in the *MAVLink 2* signing structure is to prevent cross-channel replay attacks. 
+Without the `link_id` an attacker could record a packet (such as a disarm request) on one channel, then play it back on a different channel.
+
+The intention with the link IDs is that each channel of communication between an autopilot and a GCS uses a different link ID. 
+There is no requirement that the same link ID be used in both directions however.
+--> 


### PR DESCRIPTION
This splits out an Examples section, message signing, how to stream/receive messages sections from the main doc.
The stream/recieve message doc is updated to use the interval message.

This is nowhere near enough work, but I'm stumped because I don't have the time to do it right. What I'd like to do is start with a tutorial/quickstart that shows a guided path using mavutil including connecting, sending message, receiving message, sending command, perhaps handling command. Everything else would then follow and be split out.
At the moment it is daunting, while actually most people would not need all that much.

First thing would probably be a doc on commands and command handling.

