### PR TITLE
gimbal_v2: How to address non-MAVLink gimbals

### DIFF
--- a/en/services/gimbal_v2.md
+++ b/en/services/gimbal_v2.md
@@ -124,15 +124,16 @@ If all gimbal devices should be controlled (on the component that has the gimbal
 
 #### Addressing of non-MAVLink gimbal devices  {#non_mavlink_gimbal_device_addressing}
 
-Non-MAVLink gimbal devices are gimbal that don't expose the MAVLink API but instead are connected to the gimbal manager using some other protocol. For instance, this could be a PWM gimbal connected to an autopilot.
+Non-MAVLink gimbal devices are gimbals that don't expose the MAVLink API, but instead are connected to the gimbal manager using some other protocol.
+For instance, this could be a PWM gimbal connected to an autopilot.
 
-For these cases, there needs to be a way to address such a gimbal specifically, and a way to send out the `GIMBAL_DEVICE_` messages, so that they can re mapped back to the respecive gimbal manager.
+For these cases, there needs to be a way to address such a gimbal specifically, and a way to send out the `GIMBAL_DEVICE_` messages, so that they can re mapped back to the respective gimbal manager.
 
 The solution chosen for this case is to use the numbers 1 to 6 as magic numbers for the `gimbal_device_id`. This means that the numbers 1 to 6 can't be used as MAVLink component IDs for any components involved as gimbal managers or gimbal devices.
 
 - A **gimbal manager** advertises that it implements the gimbal device "itself" by setting `gimbal_device_id` to 1 to 6. It will also send out the requested gimbal device messages from the same component ID. It will set the field in `gimbal_device_id` of [GIMBAL_DEVICE_ATTITUDE_STATUS](#GIMBAL_DEVICE_ATTITUDE_STATUS).
 
-- A **ground station** addresses a gimbal device by sending commands to the gimbal manager and specifiying the `gimbal_device_id` 1 to 6.
+- A **ground station** addresses a gimbal device by sending commands to the gimbal manager and specifying the `gimbal_device_id` 1 to 6.
 
 ## Implementation and Messages
 
@@ -247,10 +248,11 @@ For RC control, the channels will have to be manually mapped/configured to contr
 This is the same approach as is used for managing the input source for flying; it is up to the implementation to select either RC or MAVLink.
 The recommendation is to make it configurable using (for instance) a parameter.
 
-#### What about non-MAVLink gimbals
+#### Non-MAVLink gimbals
 
-A non-MAVLink gimbal needs to be connected to a gimbal manager which then takes care of sending the gimbal device messages.
-Since a non-MAVLink gimbal can't be addressed with a MAVLink component ID, the `gimbal_device_id` needs to be set to the magic value 1 to 6 which signals that the gimbal manager also "is" (or fakes to be) the gimbal device.
+A non-MAVLink gimbal needs to be connected to a gimbal manager, which then takes care of sending the gimbal device messages.
+Since a non-MAVLink gimbal can't be addressed with a MAVLink component ID, the `gimbal_device_id` needs to be set to one of the magic values (1 to 6).
+This signals that the gimbal manager also is also acting as the gimbal device.
 
 Also see [how to address non-MAVLink gimbal devices](#non_mavlink_gimbal_device_addressing).
 

--- a/en/services/gimbal_v2.md
+++ b/en/services/gimbal_v2.md
@@ -112,7 +112,7 @@ Every *Gimbal Manager* must to publish its associated *Gimbal Device* (there is 
 
 A particular MAVLink component can implement multiple gimbal managers (e.g. an autopilot can implement two gimbal managers in order to control two gimbal devices).
 
-A gimbal manager can "manage" MAVLink gimbal devices as well as non-MAVLink gimbals such as a gimbal connected with proprietary or custom interface such as PWM or SBUS. A non-MAVLink gimbal is signalled and addressed using 2 to 6 as the `gimbal_device_id` instead of the MAVLink component ID.
+A gimbal manager can "manage" MAVLink gimbal devices as well as non-MAVLink gimbals such as a gimbal connected with proprietary or custom interface such as PWM or SBUS. A non-MAVLink gimbal is signalled and addressed using 1 to 6 as the `gimbal_device_id` instead of the MAVLink component ID.
 
 #### Addressing of Gimbal MAVLink Devices {#gimbal_device_addressing}
 
@@ -128,11 +128,11 @@ Non-MAVLink gimbal devices are gimbal that don't expose the MAVLink API but inst
 
 For these cases, there needs to be a way to address such a gimbal specifically, and a way to send out the `GIMBAL_DEVICE_` messages, so that they can re mapped back to the respecive gimbal manager.
 
-The solution chosen for this case is to use the numbers 2 to 6 as magic numbers for the `gimbal_device_id`. This means that the numbers 2 to6 can't be used as MAVLink component IDs for any components involved as gimbal managers or gimbal devices.
+The solution chosen for this case is to use the numbers 1 to 6 as magic numbers for the `gimbal_device_id`. This means that the numbers 1 to 6 can't be used as MAVLink component IDs for any components involved as gimbal managers or gimbal devices.
 
-- A **gimbal manager** advertises that it implements the gimbal device "itself" by setting `gimbal_device_id` to 2 to 6. It will also send out the requested gimbal device messages from the same component ID. It will set the field in `gimbal_device_id` of [GIMBAL_DEVICE_ATTITUDE_STATUS](#GIMBAL_DEVICE_ATTITUDE_STATUS).
+- A **gimbal manager** advertises that it implements the gimbal device "itself" by setting `gimbal_device_id` to 1 to 6. It will also send out the requested gimbal device messages from the same component ID. It will set the field in `gimbal_device_id` of [GIMBAL_DEVICE_ATTITUDE_STATUS](#GIMBAL_DEVICE_ATTITUDE_STATUS).
 
-- A **ground station** addresses a gimbal device by sending commands to the gimbal manager and specifiying the `gimbal_device_id` 2 to 6.
+- A **ground station** addresses a gimbal device by sending commands to the gimbal manager and specifiying the `gimbal_device_id` 1 to 6.
 
 ## Implementation and Messages
 
@@ -250,7 +250,7 @@ The recommendation is to make it configurable using (for instance) a parameter.
 #### What about non-MAVLink gimbals
 
 A non-MAVLink gimbal needs to be connected to a gimbal manager which then takes care of sending the gimbal device messages.
-Since a non-MAVLink gimbal can't be addressed with a MAVLink component ID, the `gimbal_device_id` needs to be set to the magic value 2 to 6 which signals that the gimbal manager also "is" (or fakes to be) the gimbal device.
+Since a non-MAVLink gimbal can't be addressed with a MAVLink component ID, the `gimbal_device_id` needs to be set to the magic value 1 to 6 which signals that the gimbal manager also "is" (or fakes to be) the gimbal device.
 
 Also see [how to address non-MAVLink gimbal devices](#non_mavlink_gimbal_device_addressing).
 


### PR DESCRIPTION
This should make it clearer how the magic numbers 2..6 are used instead of MAVLink component IDs to signal that the gimbal device is the same component as the gimbal manager.

Does that make sense @Davidsastresas?