### PR TITLE
opendroneid - arming status clarification

### DIFF
--- a/en/services/opendroneid.md
+++ b/en/services/opendroneid.md
@@ -135,7 +135,7 @@ If the `HEARTBEAT` messages are not received within a required time interval, th
 This must also be indicated to the operator of the UAS.
 
 Similarly, the autopilot must listen to the [ARM_STATUS](#OPEN_DRONE_ID_ARM_STATUS) from the RID transmitter component(s) and not allow the UA to be airborne before the RID transmitter component(s) is ready.
-During flight, if the arm status indicates a failure, similar action must be taken as for a lack of `HEARTBEAT` messages.
+During flight, if the arm status indicates a failure, similar action must be taken as for a lack of `HEARTBEAT` messages from the RemoteID.
 A GCS may also listen to the [ARM_STATUS](#OPEN_DRONE_ID_ARM_STATUS) in order to provide more detailed information about UID arming failures.
 
 > **Note** In addition to the above, there are multiple additional different scenarios that must result in the Location status field being set to Emergency or Remote ID System Failure.

--- a/en/services/opendroneid.md
+++ b/en/services/opendroneid.md
@@ -136,7 +136,7 @@ This must also be indicated to the operator of the UAS.
 
 Similarly, the autopilot must listen to the [ARM_STATUS](#OPEN_DRONE_ID_ARM_STATUS) from the RID transmitter component(s) and not allow the UA to be airborne before the RID transmitter component(s) is ready.
 During flight, if the arm status indicates a failure, similar action must be taken as for a lack of `HEARTBEAT` messages from the RemoteID.
-A GCS may also listen to the [ARM_STATUS](#OPEN_DRONE_ID_ARM_STATUS) in order to provide more detailed information about UID arming failures.
+The [ARM_STATUS](#OPEN_DRONE_ID_ARM_STATUS) message must also be routed to a GCS, if present, allowing it to  provide more detailed information about RemoteID arming failures.
 
 > **Note** In addition to the above, there are multiple additional different scenarios that must result in the Location status field being set to Emergency or Remote ID System Failure.
 The exact strategy on how to avoid having multiple MAVLink components overwriting each-others emergency declarations is not yet fully defined.

--- a/en/services/opendroneid.md
+++ b/en/services/opendroneid.md
@@ -134,8 +134,9 @@ The MAVLink components in the UAS involved in the drone ID MAVLink message excha
 If the `HEARTBEAT` messages are not received within a required time interval, they must declare a malfunction of the Remote ID system and indicate this in the `status` field of the [LOCATION](#OPEN_DRONE_ID_LOCATION) message.
 This must also be indicated to the operator of the UAS.
 
-Similarly, the autopilot and GCS components must listen to the [ARM_STATUS](#OPEN_DRONE_ID_ARM_STATUS) from the RID transmitter component(s) and not allow the UA to be airborne before the RID transmitter component(s) is ready.
+Similarly, the autopilot must listen to the [ARM_STATUS](#OPEN_DRONE_ID_ARM_STATUS) from the RID transmitter component(s) and not allow the UA to be airborne before the RID transmitter component(s) is ready.
 During flight, if the arm status indicates a failure, similar action must be taken as for a lack of `HEARTBEAT` messages.
+A GCS may also listen to the [ARM_STATUS](#OPEN_DRONE_ID_ARM_STATUS) in order to provide more detailed information about UID arming failures.
 
 > **Note** In addition to the above, there are multiple additional different scenarios that must result in the Location status field being set to Emergency or Remote ID System Failure.
 The exact strategy on how to avoid having multiple MAVLink components overwriting each-others emergency declarations is not yet fully defined.


### PR DESCRIPTION
@friissoren There is a discussion in https://github.com/PX4/PX4-Autopilot/pull/21647/files#r1251208151 about the requirement for the arm status to go to the GCS.

I understand that it needs to go to the vehicle, which should not arm if the remoteid is not armed. 

I think this is saying that if the remote id is lost while flying, this should count as a malfunction and be reported in the LOCATION message status - right? (i.e. from: During flight, if the arm status indicates a failure, similar action must be taken as for a lack of `HEARTBEAT` messages.)

What is the requirement for a GCS? The way this read the GCS should be notified so it can track errors and prevent takeoff. A GCS can't prevent takeoff - it can send commands to takeoff or not send commands, but it is the autopilot that decides whether it will take off or not. 

I've tried to capture this, but would be good to know what the regulations actually state.