### PR TITLE
Camera protocol - update with info about camera addressing and missions

### DIFF
--- a/en/services/camera.md
+++ b/en/services/camera.md
@@ -106,17 +106,17 @@ It contains a bitmap of [CAMERA_CAP_FLAGS](../messages/common.md#CAMERA_CAP_FLAG
 
 > **Tip** Camera identification must be carried out before all other camera operations!
 
-The first time a heartbeat is received from a new camera component, the GCS should send it a [MAV_CMD_REQUEST_MESSAGE](../messages/common.md#MAV_CMD_REQUEST_MESSAGE) message asking for [CAMERA_INFORMATION](../messages/common.md#CAMERA_INFORMATION) (message id 259).
+The first time a heartbeat is received from a new camera component ([HEARTBEAT.type=MAV_TYPE_CAMERA](../messages/common.md#MAV_TYPE_CAMERA)), the GCS should send it a [MAV_CMD_REQUEST_MESSAGE](../messages/common.md#MAV_CMD_REQUEST_MESSAGE) message asking for [CAMERA_INFORMATION](../messages/common.md#CAMERA_INFORMATION) (message id 259).
 The camera will then respond with the a [COMMAND_ACK](../messages/common.md#COMMAND_ACK) message containing a result.
 On success (result is [MAV_RESULT_ACCEPTED](../messages/common.md#MAV_RESULT_ACCEPTED)) the camera component must then send a [CAMERA_INFORMATION](../messages/common.md#CAMERA_INFORMATION) message.
 
-[![Mermaid Sequence: Camera Id](https://mermaid.ink/img/pako:eNp9ktFKwzAUhl8l5GqDKSh4YcVBbOMsLt1sO2-shNCcanBNapoKMvbuZu0Up7BchZPvy_nDyQaXRgIOcAvvHegSIiVerKivCo38aoR1qlSN0A7Nwux_kZHHudJvKBQ1WDGcH9ZOplNvBuiOkjS_oSRHT2XdICWDHcjDBVvyOOIhYTQlz2hUKdu6MRqu8qb3Dy_ceyziKX1Y0SznjGYZmdGRDybqs-vzi8vxb71vnzmfGjlVg-ncsZw-ECNJxEl4P2CJcYDMB9g_wqTH46qPk9JsNc-9FNJlTiPUgpZI6cqcHu3VP5rHye0iZSSPFwmeYA_UQkk_k83OLbB7hRoKHPithEp0a1fgQm892jVSOKBSOWNxUIl1CxMsOmeyT13iwNkOvqH9XH8o6CU2DL__A9svQqCk4A?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNp9ktFKwzAUhl8l5GqDKSh4YcVBbOMsLt1sO2-shNCcanBNapoKMvbuZu0Up7BchZPvy_nDyQaXRgIOcAvvHegSIiVerKivCo38aoR1qlSN0A7Nwux_kZHHudJvKBQ1WDGcH9ZOplNvBuiOkjS_oSRHT2XdICWDHcjDBVvyOOIhYTQlz2hUKdu6MRqu8qb3Dy_ceyziKX1Y0SznjGYZmdGRDybqs-vzi8vxb71vnzmfGjlVg-ncsZw-ECNJxEl4P2CJcYDMB9g_wqTH46qPk9JsNc-9FNJlTiPUgpZI6cqcHu3VP5rHye0iZSSPFwmeYA_UQkk_k83OLbB7hRoKHPithEp0a1fgQm892jVSOKBSOWNxUIl1CxMsOmeyT13iwNkOvqH9XH8o6CU2DL__A9svQqCk4A)
+[![Mermaid Sequence: Camera Type](https://mermaid.ink/img/pako:eNp9kVFLwzAYRf9KyJPCFBR8sOIgpnEOl3Y2mSBWSmi_anBNapsKY-y_L2tVnMLyFJJz8t1w1zi3BeAAt_DRgckh1Oq1UdVVapBftWqcznWtjEMTKv4fcvI40-YdUVVBo4b7_bOT8dibAbpjJJE3jEj07FY1BDssk09zllHCWUJeBtmz3th_YmApD7OEPSyYkBlnQpAJO_JRVHV2fX5xefxb7wcK53MipyuwnTuUjMackyjMCL0fsMg6QPYTmj_CqMenZR8nYWIxk16ibC5ZiFowBdKmtKcHZ_V_zabRbZxwIqdxhEfYA5XShW9hvXNT7N6gghQHfltAqbqlS3FqNh7t6kI5YIV2tsFBqZYtjLDqnBUrk-PANR18Q19N_lDQS3you299swXuYKDj?type=png)](https://mermaid-js.github.io/mermaid-live-editor/edit#pako:eNp9kVFLwzAYRf9KyJPCFBR8sOIgpnEOl3Y2mSBWSmi_anBNapsKY-y_L2tVnMLyFJJz8t1w1zi3BeAAt_DRgckh1Oq1UdVVapBftWqcznWtjEMTKv4fcvI40-YdUVVBo4b7_bOT8dibAbpjJJE3jEj07FY1BDssk09zllHCWUJeBtmz3th_YmApD7OEPSyYkBlnQpAJO_JRVHV2fX5xefxb7wcK53MipyuwnTuUjMackyjMCL0fsMg6QPYTmj_CqMenZR8nYWIxk16ibC5ZiFowBdKmtKcHZ_V_zabRbZxwIqdxhEfYA5XShW9hvXNT7N6gghQHfltAqbqlS3FqNh7t6kI5YIV2tsFBqZYtjLDqnBUrk-PANR18Q19N_lDQS3you299swXuYKDj)
 
 <!-- Original diagram
 sequenceDiagram;
     participant GCS
     participant MAVLink Camera
-    MAVLink Camera->>GCS: HEARTBEAT [cmp id: MAV_COMP_ID_CAMERA] (first)
+    MAVLink Camera->>GCS: HEARTBEAT [type: MAV_TYPE_CAMERA]
     GCS->>MAVLink Camera: MAV_CMD_REQUEST_MESSAGE(param1=259)
     GCS->>GCS: Start timeout
     MAVLink Camera->>GCS: COMMAND_ACK

--- a/en/services/camera.md
+++ b/en/services/camera.md
@@ -33,7 +33,7 @@ MAVLink cameras are identified and addressed by their system and component id.
 
 Components that have non-MAVLink cameras attached, such as companion computers, are expected expose each of them as a separate MAVLink camera component with its own `HEARTBEAT`.
 
-The exception is the _autopilot_ component, which can "proxy" up to 6 attached non-MAVLink cameras: these are identified by a "camera device id" in messages and commands.
+The exception is the _autopilot_ component, which can "proxy" up to 6 attached non-MAVLink cameras: these are identified by a `camera_device_id` field in messages and `Target Camera ID` label in commands.
 
 #### Camera Messages
 
@@ -49,6 +49,7 @@ MAVLink cameras are sent commands addressed using their system and component ids
 
 To send commands to autopilot-attached cameras, the command should be send to the autopilot component.
 The device id of the target attached camera must further be set in the command's `Target Camera ID` parameter (the index and precise label of this parameter may vary).
+The autopilot is required to respond to the command with `COMMAND_ACK`, populating the [COMMAND_ACK.result_param2](../messages/common.md#COMMAND_ACK) field with the id of the targetted autopilot connected camera, if any.
 
 Note that the `Target Camera ID` parameter should be set to `0` in order to target all cameras, or if targeting a MAVLink camera.
 
@@ -63,8 +64,8 @@ When using a camera MAV_CMD in a mission, the `id` parameter (if present) indica
 
 When processing a camera item in a mission the autopilot should:
 
-- For `id` values of `1`-`6`, perform the specified camera action on the connected camera if it exists, and otherwise log an error.
-- For other `id` values, re-emit the `MAV_CMD` using the command protocol, setting the target component id to the `id` set in the camera mission item.
+- For `Target Camera ID` values of `1`-`6`, perform the specified camera action on the connected camera if it exists, and otherwise log an error.
+- For other `Target Camera ID` values, re-emit the `MAV_CMD` using the command protocol, setting the target component id to the `id` set in the camera mission item.
   It should also log any errors from the returned `COMMAND_ACK`.
 
 > **Note** Flight stacks that predate using a camera id typically re-emit the mission command addressed either to the broadcast component id (`0`) or to [MAV_COMP_ID_CAMERA](../messages/common.md#MAV_COMP_ID_CAMERA).
@@ -81,8 +82,8 @@ Values of [MAV_COMP_ID_CAMERA](../messages/common.md#MAV_COMP_ID_CAMERA) to [MAV
 
 A GCS should start the [Camera Identification](#camera_identification) process the first time it detects a `HEARTBEAT` from a new:
 
-- Autopilot, in order to detect autopilot-connected cameras.
 - MAVLink camera component.
+- Autopilot, in order to detect autopilot-connected cameras.
 
 > **Note** If a receiving system stops receiving heartbeats from the camera it is assumed to be _disconnected_, and should be removed from the list of available cameras.
 > If heartbeats are again detected, the _camera identification_ process below must be restarted from the beginning.

--- a/en/services/camera.md
+++ b/en/services/camera.md
@@ -62,8 +62,6 @@ When using a camera MAV_CMD with the [command protocol](../services/command.md):
   - Specify the vehicle system id.
   - Specify the camera component id.
   - Set the `id` parameter to 0.
-    - If the MAVLink camera has multiple sensors (e.g. visible light vs IR) you could set a value from 1-6 to indicate which sensor process the command.
-    - If `id` is not supported by the camera or is set to 0 then all sensors should be triggered.
 
 #### Camera Addressing in Missions
 


### PR DESCRIPTION
Work related to https://github.com/mavlink/mavlink/pull/2024

This documents the presence of the `id` parameter in the image command. I've tried to make it clear how addressing works both before and after, and in the command protocol and missions.

@julianoes @rmackay9 @Davidsastresas  A couple of things popped up:

1. MAVLink cameras send a `HEARTBEAT` with the camera type, which tells GCS that it should query for CAMERA_INFORMATION using [MAV_CMD_REQUEST_MESSAGE](https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_MESSAGE). However an autopilot or onboard computer has its own component ID and type so what should trigger GCS to know it should query the onboard computer?

   The obvious answer is that a GCS could choose NOT to wait for heartbeats, but instead fire off `MAV_CMD_REQUEST_MESSAGE` for camera information to the system ID with component id = 0. Then all components that support cameras should fire back a response. I think this makes sense except:
   - Do we have to worry about multiple ACK?
   - Do we suggest no longer querying cameras individually.

   Alternatively we suggest that a GCS must also query the onboard computer and autopilot. This has the benefit that it is the same query process as currently. However it does mean that if some other component ends up managing a set of cameras we won't know to address it unless it outputs the heartbeat. 
   
   Thoughts?

2. Each proxied camera has a "camera id". So if I want to send a command to the non-mavlink camera attached to a companion computer, then I send the command to the companion with target address of the companion, and the camera's specific camera id. Similarly, if I want to send the command to a camera attached to the autopilot I an address it.

   However I think we missed the case of a mission command for a camera attached to an onboard computer. 

   We can specify the id in a mission of 1-6 but this will be executed by the autopilot on ITS connected cameras. There is no way to say in a mission that you want the command to go to the onboard computer.

   Thoughts? Solutions? 

3. How can a system tell if the `id` is not supported? Do they need to be able to?