### PR TITLE
battery.md - de smart battery-ify the protocol

### DIFF
--- a/en/services/battery.md
+++ b/en/services/battery.md
@@ -1,14 +1,20 @@
 # Battery Protocol
 
 MAVLink provides a number of messages for providing battery information:
-- [BATTERY_STATUS](#BATTERY_STATUS): Battery status information that changes regularly.
-  - Emitted for both "dumb" and "smart" batteries at around 0.5 Hz (for each battery).
-  - Smart batteries may provide [fault](#MAV_BATTERY_FAULT) and [mode](#MAV_BATTERY_MODE) information in this message, which are typically not provided by "dumb" batteries.
-- [SMART_BATTERY_INFO](#SMART_BATTERY_INFO): Battery information that changes rarely, if ever (e.g. device name).
-  - Should be emitted smart batteries.
+
+- [BATTERY_STATUS](#BATTERY_STATUS): Battery status information that changes regularly:
+
+  - Emitted at around 0.5 Hz (for each battery).
+  - Some batteries may provide [fault](#MAV_BATTERY_FAULT) and [mode](#MAV_BATTERY_MODE) information in this message.
+ 
+  > **Note** `BATTERY_STATUS` is expected to be superseded by [BATTERY_STATUS_V2](../messages/development.html#BATTERY_STATUS_V2).
+  > For more information see [RFC 0018 - Improved Battery Status Reporting](https://github.com/mavlink/rfcs/pull/19).
+
+- [BATTERY_INFO](#BATTERY_INFO): Battery information that changes rarely, if ever (e.g. device name):
+
   - Emit on connection and/or when requested using [MAV_CMD_REQUEST_MESSAGE](../messages/common.md#MAV_CMD_REQUEST_MESSAGE).
 
-The messages should be sent individually for each battery in the system (the messages have an instance id field that is used to identify the corresponding battery).
+The messages should be sent individually for each battery in the system (the messages have an instance `id` field that is used to identify the corresponding battery).
 It is up to the GCS to provide an appropriate mechanism that allows the user to assess the aggregate battery status on systems that have multiple batteries. 
 
 > **Note** There is no standardized mechanism to report the "aggregate" battery state on a multi-battery system.
@@ -20,27 +26,26 @@ It is up to the GCS to provide an appropriate mechanism that allows the user to 
 Message | Description
 -- | --
 <span id="BATTERY_STATUS"></span>[BATTERY_STATUS](../messages/common.md#BATTERY_STATUS) | Battery message used for frequent status update - e.g. of current capacity, voltages, faults, etc.
-<span id="SMART_BATTERY_INFO"></span>[SMART_BATTERY_INFO](../messages/common.md#SMART_BATTERY_INFO) (WIP) |  Smart battery message used for invariant or infrequently changing data - e.g. battery name, battery full/empty capacity and voltages etc.
-
+<span id="BATTERY_INFO"></span>[BATTERY_INFO](../messages/common.md#BATTERY_INFO) (WIP) | Battery message used for invariant or infrequently changing data - e.g. battery name, battery full/empty capacity and voltages etc.
 
 Enum | Description
 -- | --
-<span id="MAV_BATTERY_FAULT"></span>[MAV_BATTERY_FAULT](../messages/common.md#MAV_BATTERY_FAULT) | Fault/health indications. Typically only supplied by smart batteries.
-<span id="MAV_BATTERY_MODE"></span>[MAV_BATTERY_MODE](../messages/common.md#MAV_BATTERY_MODE) | Smart battery mode.
+<span id="MAV_BATTERY_FAULT"></span>[MAV_BATTERY_FAULT](../messages/common.md#MAV_BATTERY_FAULT) | Fault/health indications.
+<span id="MAV_BATTERY_MODE"></span>[MAV_BATTERY_MODE](../messages/common.md#MAV_BATTERY_MODE) | Battery mode.
 
 
 ## Battery Components
 
-Smart batteries that are connected to a flight controller via **a non-MAVLink bus** are treated as part of the flight controller component.
+Batteries that are connected to a flight controller via **a non-MAVLink bus** are treated as part of the flight controller component.
 Specifically, the battery messages are emitted with the autopilot system and component ids, and the `MAV_TYPE` for the type of vehicle.
 
-Smart batteries that are distinct components on the MAVLink network must:
+Batteries that are distinct components on the MAVLink network must:
 - emit a [HEARTBEAT](../messages/common.md#HEARTBEAT) with `HEARTBEAT.type`=[MAV_TYPE_BATTERY](../messages/common.md#MAV_TYPE_BATTERY)
 -have a unique component ID within the MAVLink system.
   [MAV_COMP_ID_BATTERY](../messages/common.md#MAV_COMP_ID_BATTERY) and [MAV_COMP_ID_BATTERY2](../messages/common.md#MAV_COMP_ID_BATTERY2) should be used by default for the first two battery instances.
   Subsequent instances can use any spare/unused ID.
 
-> **Note** Ground stations (and other components) that are interested in battery messages should differentiate batteries based on `BATTERY_STATUS.id`/`SMART_BATTERY_INFO.id`.
+> **Note** Ground stations (and other components) that are interested in battery messages should differentiate batteries based on `BATTERY_STATUS.id`/`BATTERY_INFO.id`.
 
 
 ## A Note on SYS_STATUS


### PR DESCRIPTION
SMART_BATTERY_INFO was renamed to BATTERY_INFO and updated to match the corresponding CAN message in https://github.com/mavlink/mavlink/pull/2070.

This updates the battery protocol docs in line with that change.