### PR TITLE
Fixed broken link for UDP example: 'examples/linux' -> 'examples/c'

### DIFF
--- a/en/mavgen_c/example_c_udp.md
+++ b/en/mavgen_c/example_c_udp.md
@@ -1,6 +1,6 @@
 # MAVLink C UDP Example
 
-The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/linux) is a simple C example that sends some data to _QGroundControl_ using MAVLink over UDP.
+The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/c) is a simple C example that sends some data to _QGroundControl_ using MAVLink over UDP.
 _QGroundControl_ responds with heartbeats and other messages, which are then printed by this program.
 
 > **Note** The example should work on any Unix-like system (Linux, MacOS, BSD, etc.).
@@ -27,7 +27,7 @@ The following instructions show how to build and run the example.
 
    > **Note** You can put/generate the library wherever you like, but the build command below assumes they are located in directory named **include** below the MAVLink root directory.
 
-1. Open a terminal and navigate to [examples/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+1. Open a terminal and navigate to [examples/c](https://github.com/mavlink/mavlink/tree/master/examples/c)
 1. Compile with GCC using the following command:
 
    ```sh
@@ -55,7 +55,7 @@ The following instructions show how to build and run the example.
 1. The example should start displaying the received data in the terminal:
 
    ```sh
-   ~/github/mavlink/examples/linux$ ./mavlink_udp
+   ~/github/mavlink/examples/c$ ./mavlink_udp
    Bytes Received: 17
    Datagram: fe 09 00 ff 00 00 00 00 00 00 06 08 c0 04 03 19 87
    Received packet: SYS: 255, COMP: 0, LEN: 9, MSG ID: 0

--- a/ko/examples/c_udp.md
+++ b/ko/examples/c_udp.md
@@ -1,6 +1,6 @@
 # MAVLink C UDP Example
 
-The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/linux) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
+The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/c) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
 
 > **Note** The example should work on any Unix-like system (Linux, MacOS, BSD, etc.). These instructions were tested on a clean *Ubuntu LTS 16.04* installation using the default version of *gcc* (5.4.0).
 
@@ -16,7 +16,7 @@ The following instructions show how to build and run the example.
     
     > **Note** You can put/generate the library wherever you like, but the build command below assumes they are located in directory named **include** below the MAVLink root directory.
 
-2. Open a terminal and navigate to [examples/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+2. Open a terminal and navigate to [examples/c](https://github.com/mavlink/mavlink/tree/master/examples/c)
 
 3. Compile with GCC using the following command:
     
@@ -42,7 +42,7 @@ The following instructions show how to build and run the example.
 
 6. The example should start displaying the received data in the terminal:
     
-        ~/github/mavlink/examples/linux$ ./mavlink_udp
+        ~/github/mavlink/examples/c$ ./mavlink_udp
         Bytes Received: 17
         Datagram: fe 09 00 ff 00 00 00 00 00 00 06 08 c0 04 03 19 87 
         Received packet: SYS: 255, COMP: 0, LEN: 9, MSG ID: 0

--- a/ko/examples/example_c_udp.md
+++ b/ko/examples/example_c_udp.md
@@ -1,6 +1,6 @@
 # MAVLink C UDP Example
 
-The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/linux) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
+The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/c) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
 
 > **Note** The example should work on any Unix-like system (Linux, MacOS, BSD, etc.). These instructions were tested on a clean *Ubuntu LTS 16.04* installation using the default version of *gcc* (5.4.0).
 
@@ -16,7 +16,7 @@ The following instructions show how to build and run the example.
     
     > **Note** You can put/generate the library wherever you like, but the build command below assumes they are located in directory named **include** below the MAVLink root directory.
 
-2. Open a terminal and navigate to [examples/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+2. Open a terminal and navigate to [examples/c](https://github.com/mavlink/mavlink/tree/master/examples/c)
 
 3. Compile with GCC using the following command:
     
@@ -42,7 +42,7 @@ The following instructions show how to build and run the example.
 
 6. The example should start displaying the received data in the terminal:
     
-        ~/github/mavlink/examples/linux$ ./mavlink_udp
+        ~/github/mavlink/examples/c$ ./mavlink_udp
         Bytes Received: 17
         Datagram: fe 09 00 ff 00 00 00 00 00 00 06 08 c0 04 03 19 87 
         Received packet: SYS: 255, COMP: 0, LEN: 9, MSG ID: 0

--- a/ko/mavgen_c/example_c_udp.md
+++ b/ko/mavgen_c/example_c_udp.md
@@ -1,6 +1,6 @@
 # MAVLink C UDP Example
 
-The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/linux) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
+The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/c) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
 
 > **Note** The example should work on any Unix-like system (Linux, MacOS, BSD, etc.). These instructions were tested on a clean *Ubuntu LTS 20.04* installation using the default version of *gcc* (9.3.0).
 
@@ -23,7 +23,7 @@ The following instructions show how to build and run the example.
 
    > **Note** You can put/generate the library wherever you like, but the build command below assumes they are located in directory named **include** below the MAVLink root directory.
 
-1. Open a terminal and navigate to [examples/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+1. Open a terminal and navigate to [examples/c](https://github.com/mavlink/mavlink/tree/master/examples/c)
 1. Compile with GCC using the following command:
    ```bash
    gcc -std=c99 -I ../../include/common -o mavlink_udp mavlink_udp.c
@@ -45,7 +45,7 @@ The following instructions show how to build and run the example.
 
 1. The example should start displaying the received data in the terminal:
    ```
-   ~/github/mavlink/examples/linux$ ./mavlink_udp
+   ~/github/mavlink/examples/c$ ./mavlink_udp
    Bytes Received: 17
    Datagram: fe 09 00 ff 00 00 00 00 00 00 06 08 c0 04 03 19 87 
    Received packet: SYS: 255, COMP: 0, LEN: 9, MSG ID: 0

--- a/kr/examples/c_udp.md
+++ b/kr/examples/c_udp.md
@@ -1,6 +1,6 @@
 # MAVLink C UDP Example
 
-The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/linux) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. 
+The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/c) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP.
 *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
 
 > **Note** The example should work on any Unix-like system (Linux, MacOS, BSD, etc.). 
@@ -17,7 +17,7 @@ The following instructions show how to build and run the example.
    <span></span>
    > **Note** You can put/generate the library wherever you like, but the build command below assumes they are located in directory named **include** below the MAVLink root directory.
    
-1. Open a terminal and navigate to [examples/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+1. Open a terminal and navigate to [examples/c](https://github.com/mavlink/mavlink/tree/master/examples/c)
 1. Compile with GCC using the following command:
    ```bash
    gcc -std=c99 -I ../../include/common -o mavlink_udp mavlink_udp.c
@@ -40,7 +40,7 @@ The following instructions show how to build and run the example.
 
 1. The example should start displaying the received data in the terminal:
    ```
-   ~/github/mavlink/examples/linux$ ./mavlink_udp
+   ~/github/mavlink/examples/c$ ./mavlink_udp
    Bytes Received: 17
    Datagram: fe 09 00 ff 00 00 00 00 00 00 06 08 c0 04 03 19 87 
    Received packet: SYS: 255, COMP: 0, LEN: 9, MSG ID: 0

--- a/zh/examples/c_udp.md
+++ b/zh/examples/c_udp.md
@@ -16,7 +16,7 @@
     
     > **注意** 您可以在您喜欢的地方放置/生成的库，但下面的建设命令假定它们位于 **包括** 在 MAVLink 根目录下。
 
-2. 打开终端并导航到 [实例/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+2. 打开终端并导航到 [实例/c](https://github.com/mavlink/mavlink/tree/master/examples/c)
 
 3. 使用下列命令编译GCC：
     
@@ -42,7 +42,7 @@
 
 6. 例子应该开始显示终端收到的数据：
     
-        ~/github/mavlink/examples/linux$ ./mavlink_udp
+        ~/github/mavlink/examples/c$ ./mavlink_udp
         Bytes Received: 17
         Datagram: fe 09 00 ff 00 00 00 00 00 00 06 08 c0 04 03 19 87 
         Received packet: SYS: 255, COMP: 0, LEN: 9, MSG ID: 0

--- a/zh/examples/example_c_udp.md
+++ b/zh/examples/example_c_udp.md
@@ -16,7 +16,7 @@
     
     > **注意** 您可以在您喜欢的地方放置/生成的库，但下面的建设命令假定它们位于 **包括** 在 MAVLink 根目录下。
 
-2. 打开终端并导航到 [实例/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+2. 打开终端并导航到 [实例/c](https://github.com/mavlink/mavlink/tree/master/examples/c)
 
 3. 使用下列命令编译GCC：
     
@@ -42,7 +42,7 @@
 
 6. 例子应该开始显示终端收到的数据：
     
-        ~/github/mavlink/examples/linux$ ./mavlink_udp
+        ~/github/mavlink/examples/c$ ./mavlink_udp
         Bytes Received: 17
         Datagram: fe 09 00 ff 00 00 00 00 00 00 06 08 c0 04 03 19 87 
         Received packet: SYS: 255, COMP: 0, LEN: 9, MSG ID: 0

--- a/zh/mavgen_c/example_c_udp.md
+++ b/zh/mavgen_c/example_c_udp.md
@@ -1,6 +1,6 @@
 # MAVLink C UDP Example
 
-The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/linux) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
+The [MAVLink UDP Example](https://github.com/mavlink/mavlink/tree/master/examples/c) is a simple C example that sends some data to *QGroundControl* using MAVLink over UDP. *QGroundControl* responds with heartbeats and other messages, which are then printed by this program.
 
 > **Note** The example should work on any Unix-like system (Linux, MacOS, BSD, etc.). These instructions were tested on a clean *Ubuntu LTS 20.04* installation using the default version of *gcc* (9.3.0).
 
@@ -23,7 +23,7 @@ The following instructions show how to build and run the example.
 
    > **Note** You can put/generate the library wherever you like, but the build command below assumes they are located in directory named **include** below the MAVLink root directory.
 
-1. Open a terminal and navigate to [examples/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux)
+1. Open a terminal and navigate to [examples/c](https://github.com/mavlink/mavlink/tree/master/examples/c)
 1. Compile with GCC using the following command:
    ```bash
    gcc -std=c99 -I ../../include/common -o mavlink_udp mavlink_udp.c
@@ -45,7 +45,7 @@ The following instructions show how to build and run the example.
 
 1. The example should start displaying the received data in the terminal:
    ```
-   ~/github/mavlink/examples/linux$ ./mavlink_udp
+   ~/github/mavlink/examples/c$ ./mavlink_udp
    Bytes Received: 17
    Datagram: fe 09 00 ff 00 00 00 00 00 00 06 08 c0 04 03 19 87 
    Received packet: SYS: 255, COMP: 0, LEN: 9, MSG ID: 0


### PR DESCRIPTION
Fixed broken link for UDP example: [examples/linux](https://github.com/mavlink/mavlink/tree/master/examples/linux) -> [examples/c](https://github.com/mavlink/mavlink/tree/master/examples/c)