### PR TITLE
DOCS: Name TIMESYNC as the replacement of PING

### DIFF
--- a/en/messages/common.md
+++ b/en/messages/common.md
@@ -1431,6 +1431,9 @@ payload | `uint8_t[251]` | Variable length payload. The length is defined by the
 
 ### TIMESYNC (111) {#TIMESYNC}
 
+
+Time Synchronization Protocol: https://mavlink.io/en/services/timesync.html.
+
 Time synchronization message.
 The message is used for both timesync requests and responses.
 The request is sent with `ts1=syncing component timestamp` and `tc1=0`, and may be broadcast or targeted to a specific system/component.

--- a/en/messages/common.md
+++ b/en/messages/common.md
@@ -95,7 +95,7 @@ time_boot_ms | `uint32_t` | ms | Timestamp (time since system boot).
 
 ### PING (4) — [DEP] {#PING}
 
-<span class="warning">**DEPRECATED:** Replaced By [SYSTEM_TIME](#SYSTEM_TIME) (2011-08) — to be removed / merged with [SYSTEM_TIME](#SYSTEM_TIME))</span>
+<span class="warning">**DEPRECATED:** Replaced By [TIMESYNC](#TIMESYNC)</span>
 
 A ping message either requesting or responding to a ping. This allows to measure the system latencies, including serial port, radio modem and UDP connections. The ping microservice is documented at https://mavlink.io/en/services/ping.html
 


### PR DESCRIPTION
Correct false information on PING command replacement. SYSTEM_TIME has nothing to do with what PING is supposed to do. The correct replacement here is TIMESYNC.