### PR TITLE
Update trajectory.md - path planning intrface deprecated

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -56,7 +56,6 @@
   - [File Transfer Protocol (FTP)](services/ftp.md)
   - [Landing Target Protocol](services/landing_target.md)
   - [Ping Protocol](services/ping.md)
-  - [Path Planning (Trajectory) Protocol](services/trajectory.md)
   - [Battery Protocol](services/battery.md)
   - [Terrain Protocol](services/terrain.md)
   - [Tunnel Protocol](services/tunnel.md)

--- a/en/services/index.md
+++ b/en/services/index.md
@@ -29,7 +29,6 @@ The main microservices are shown in the sidebar (most are listed below):
 - [File Transfer Protocol (FTP)](../services/ftp.md)
 - [Landing Target Protocol](../services/landing_target.md)
 - [Ping Protocol](../services/ping.md)
-- [Path Planning Protocol](../services/trajectory.md) (Trajectory Interface)
 - [Battery Protocol](../services/battery.md)
 - [Terrain Protocol](../services/terrain.md)
 - [Tunnel Protocol](../services/tunnel.md)

--- a/en/services/trajectory.md
+++ b/en/services/trajectory.md
@@ -1,5 +1,10 @@
 # Path Planning Protocol (Trajectory Interface)
 
+::: warning
+This interface is deprecated.
+The interface was present in PX4 v1.11 to PX4 v1.14, but is no longer used in any current flight stacks.
+:::
+
 The path planning protocol (a.k.a. trajectory interface) is a general-purpose protocol for a system to request dynamic path planning from another system (i.e. for an autopilot to request a path from a companion computer).
 
 The protocol is primarily intended for cases where constraints on the path to a destination are unknown or may change dynamically, but it can also be used for any other path management activities.


### PR DESCRIPTION
This deprecates the Path planning interface, reflecting its removal from all flight stacks. 
Removed from the sidebar, but still findable by search.