### PR TITLE
Update installation.md To Make Directions More Clear

### DIFF
--- a/en/getting_started/installation.md
+++ b/en/getting_started/installation.md
@@ -33,12 +33,13 @@ To install the MAVLink toolchain:
 
    ```
    git clone https://github.com/mavlink/mavlink.git --recursive
-   ```
+   cd mavlink
+2. ```
 
 1. Install the required packages:
 
    ```
-   python3 -m pip install -r mavlink/pymavlink/requirements.txt
+   python3 -m pip install -r pymavlink/requirements.txt
    ```
 
 Now you are ready to [Generate MAVLink Libraries](../getting_started/generate_libraries.md).

--- a/en/getting_started/installation.md
+++ b/en/getting_started/installation.md
@@ -34,9 +34,9 @@ To install the MAVLink toolchain:
    ```
    git clone https://github.com/mavlink/mavlink.git --recursive
    cd mavlink
-2. ```
+   ```
 
-1. Install the required packages:
+2. Install the required packages:
 
    ```
    python3 -m pip install -r pymavlink/requirements.txt

--- a/en/getting_started/installation.md
+++ b/en/getting_started/installation.md
@@ -38,7 +38,7 @@ To install the MAVLink toolchain:
 1. Install the required packages:
 
    ```
-   python3 -m pip install -r pymavlink/requirements.txt
+   python3 -m pip install -r mavlink/pymavlink/requirements.txt
    ```
 
 Now you are ready to [Generate MAVLink Libraries](../getting_started/generate_libraries.md).


### PR DESCRIPTION
This pull request makes a minor update to the installation instructions for the MAVLink toolchain, specifically correcting the path to the requirements file.

* Updated the `pip install` command in `en/getting_started/installation.md` to use the correct path: `mavlink/pymavlink/requirements.txt` instead of `pymavlink/requirements.txt`.