### PR TITLE
Fix deep-link anchor offset and improve layout stability in Firefox

### DIFF
--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -48,6 +48,27 @@ export default {
     };
     onMounted(() => {
       initZoom();
+      // Re-scroll to hash after fonts/layout settle. Firefox does not re-scroll
+      // after late layout shifts on huge pages (e.g. common.html), so the
+      // initial anchor jump lands far off. Run only on initial load.
+      if (inBrowser && location.hash) {
+        const id = decodeURIComponent(location.hash.slice(1));
+        const fontsReady = document.fonts?.ready ?? Promise.resolve();
+        const loadReady =
+          document.readyState === "complete"
+            ? Promise.resolve()
+            : new Promise((r) =>
+                window.addEventListener("load", r, { once: true })
+              );
+        Promise.all([fontsReady, loadReady]).then(() => {
+          requestAnimationFrame(() =>
+            requestAnimationFrame(() => {
+              const el = document.getElementById(id);
+              if (el) el.scrollIntoView();
+            })
+          );
+        });
+      }
     });
     watch(
       () => route.path,

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -157,6 +157,15 @@
   display: inline; /* block by default set by vitepress */
 }
 
+/* Fix deep-link anchor offset under fixed navbar.
+   Also guards against Firefox layout-shift drift on huge pages (e.g. common.html). */
+html {
+  scroll-padding-top: calc(var(--vp-nav-height, 64px) + 16px);
+}
+:target {
+  scroll-margin-top: calc(var(--vp-nav-height, 64px) + 16px);
+}
+
 /* Make content area a little wider to improve tables */
 .content-container {
   max-width: 100% !important;


### PR DESCRIPTION
## Issue
When jumping to enum values, like [FAILURE_TYPE](https://mavlink.io/en/messages/common.html#FAILURE_TYPE) from the [MAV_CMD_INJECT_FAILURE](https://mavlink.io/en/messages/common.html#MAV_CMD_INJECT_FAILURE) entry, i ended often somewhere else (in that example in the middle of the AIS_TYPE  entry).

## Solution                                     
                                                                                                                
  Fix anchor deep-link drift on mavlink.io (e.g. `common.html#FAILURE_TYPE`). Anchors landed under fixed navbar in all browsers, and far off-section in Firefox on huge pages.                            
                                                                                                                                                                                                          
  ## Cause                                                                                                                                                                                                
                                                                                                                                                                                                          
  1. No `scroll-padding-top` / `scroll-margin-top` — anchor hidden under VitePress navbar (~64px).                                                                                                        
  2. On `common.html` (~1.1 MB, thousands of headings/tables), browser scrolls at parse time. Web fonts + progressive table layout shift content after. Firefox does not re-scroll once layout settles;
  Chrome's paint-holding masks it.                                                                                                                                                                        
   
  ## Fix                                                                                                                                                                                                  
                                                         
  - `.vitepress/theme/style.css` — `html { scroll-padding-top }` + `:target { scroll-margin-top }` using `--vp-nav-height` (fallback 64px) + 16px.                                                        
  - `.vitepress/theme/index.js` — on mount, if `location.hash` set, wait for `document.fonts.ready` + `window.load` + 2× `rAF`, then re-run `scrollIntoView()`. Initial-load only.
                                                                                                                                                                                                          
  ## Before / After                                      
                                                                                                                                                                                                          
  **Before (Firefox, broken):**                          

https://github.com/user-attachments/assets/0f0e2790-3945-4757-a3ed-f63d7afc1b2b
   
  **After (Firefox, fixed):**                                                                                                                                                                             

https://github.com/user-attachments/assets/292a3d68-a2e2-40b6-a9e2-9c9e521f8c6f

  ## Test plan

  - [x] Firefox: `/en/messages/common.html#FAILURE_TYPE` lands on heading                                                                                                                                 
  - [x] Chrome: same URLs — no regression, no double-jump flicker                                                                                                                                         
  - [x] Smaller page (`faq.html#…`) — no over-correction                                                                                                                                                  
  - [x] In-page TOC click — VitePress smooth-scroll preserved
  - [x] Hard reload (Ctrl+Shift+R) on deep link — fix survives cold cache 