### PR TITLE
Remove arbitary x-track from loiter

### DIFF
--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -429,10 +429,10 @@ The remaining parameters (xtrack and heading) apply only to forward flying aircr
 
 Xtrack and heading define the location at which a forward flying (fixed wing) vehicle will _exit the loiter circle, and its path to the next waypoint_ (these apply only to `MAV_CMD_NAV_LOITER_TIME` and `MAV_CMD_NAV_LOITER_TURNS`).
 
-| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | Units                   |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False)                                                                                                                                                                                                                                                                                                                                                                                                                                                                         | min:0 max:1 increment:1 |
-| 4: Xtrack Location  | Sets xtrack path or exit location: 0 for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), 1 to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. Otherwise the angle (in degrees) between the tangent of the loiter circle and the center xtrack at which the vehicle must leave the loiter (and converge to the center xtrack). NaN to use the current system default xtrack behaviour. |
+| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                             | Units                   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False)                                                                                                                                                                                                                                                                                             | min:0 max:1 increment:1 |
+| 4: Xtrack Location  | Sets xtrack path or exit location: `0` for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), `1` to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. |
 
 The recommended values (and resulting paths) are those shown below.
 
@@ -457,12 +457,6 @@ The Xtrack parameter independently defines the path and exit location:
 - `xtrack=NaN`: Exit the loiter using "system specific default behaviour".
   - The vehicle must still respect the heading required param.
   - Usually this is synonymous with `xtrack=0`
-- `xtrack=any other value`: Exit the loiter when the vehicle heading (tangent) makes the specified angle in degrees to the center xtrack.
-  Converge to the center xtrack.
-  The vehicle must still respect the `heading required` param (some xtrack values may not be possible with this condition true).
-  This allows callers to specify how quickly the vehicle converges to the center xtrack. For example, the image below shows the vehicle exiting the loiter at 30 degrees.
-
-  ![Loiter angle](../../assets/protocols/mission_loiter/xtrack_30.png)
 
 ## Implementations
 


### PR DESCRIPTION
This removes info about controlling the x-track leave angle, which was removed in https://github.com/mavlink/mavlink/pull/2492