### PR TITLE
Remove all references to matrixpilot.xml dialect

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -70,7 +70,6 @@
     "libevents",
     "loweheiser",
     "lxml",
-    "matrixpilot",
     "mavconn",
     "mavcrc",
     "mavexpression",

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -76,7 +76,6 @@
   - [cubepilot.xml](messages/cubepilot.md)
   - [icarous.xml](messages/icarous.md)
   - [loweheiser.xml](messages/loweheiser.md)
-  - [matrixpilot.xml](messages/matrixpilot.md)
   - [paparazzi.xml](messages/paparazzi.md)
   - [storm32.xml](messages/storm32.md)
   - [uAvionix.xml](messages/uAvionix.md)

--- a/en/guide/define_xml_element.md
+++ b/en/guide/define_xml_element.md
@@ -511,7 +511,6 @@ ArduPilot: 211, 212, 83, 42000-42005, 42424 (MAG_CAL) 42426, 42650
 ASLUAV : 40001,40002
 Autoquad 1,2,4
 Common - 16 - 34, 80-85, 92 - 95, 112-115, 159, 176 - 186, 189 - 252, 300, 400, 410, 500, 510, 530, 2000-2003, 2500, scattered up to 5000 then 30001-31014 (scattered
-matrixpilot : 0
 -->
 
 #### Reserved/Undefined Parameters {#reserved}


### PR DESCRIPTION
matrixpilot.xml has been removed from the MAVLink message definitions in https://github.com/mavlink/mavlink/pull/2518

This cleans up the remaining references: SUMMARY.md nav entries, dialects/README message lists, define_xml_element.md MAVLink ID table, cspell word list. Translations should be cleaned up at a later point after round trip through crowdin.
