### PR TITLE
Improve search-engine crawlability of docs

### DIFF
--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
   base: "",
   lastUpdated: true,
   sitemap: {
-    hostname: "https://mavlink.io/",
+    hostname: "https://mavlink.io",
   },
   srcExclude: [
     "de/**/*.md",

--- a/.vitepress/config.mjs
+++ b/.vitepress/config.mjs
@@ -12,6 +12,10 @@ export default defineConfig({
   description: "MAVLink Developer Guide",
   //base: process.env.BRANCH_NAME ? "/" + process.env.BRANCH_NAME + "/" : "", //Build doesn't use branches!
   base: "",
+  lastUpdated: true,
+  sitemap: {
+    hostname: "https://mavlink.io/",
+  },
   srcExclude: [
     "de/**/*.md",
     "ja/**/*.md",
@@ -115,8 +119,36 @@ export default defineConfig({
     },
   },
   //Logs every page loaded on build. Good way to catch errors not caught by other things.
+  //Also injects per-page SEO metadata (description, OpenGraph, canonical) into the
+  //server-rendered <head> so message pages are better crawled/snippeted by search engines.
   async transformPageData(pageData, { siteConfig }) {
     console.log(pageData.filePath);
+
+    const desc =
+      pageData.frontmatter.description ||
+      pageData.description ||
+      (pageData.title
+        ? `${pageData.title} — MAVLink message, enum and command reference.`
+        : "MAVLink Developer Guide");
+
+    // Set pageData.description so VitePress's own <meta name="description"> uses it
+    // (pushing a second description tag in head would be deduped in favour of the default).
+    pageData.description = desc;
+
+    const url =
+      "https://mavlink.io/" +
+      pageData.relativePath
+        .replace(/(^|\/)index\.md$/, "$1")
+        .replace(/\.md$/, ".html");
+
+    pageData.frontmatter.head ??= [];
+    pageData.frontmatter.head.push(
+      ["meta", { property: "og:title", content: pageData.title }],
+      ["meta", { property: "og:description", content: desc }],
+      ["meta", { property: "og:type", content: "article" }],
+      ["meta", { property: "og:url", content: url }],
+      ["link", { rel: "canonical", href: url }]
+    );
   },
 
   //

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "docs:buildwin": "set NODE_OPTIONS=--max_old_space_size=8192 && vitepress build .",
     "docs:build_ubuntu": "NODE_OPTIONS='--max-old-space-size=8192' vitepress build .",
     "docs:preview": "vitepress preview .",
-    "docs:sitemap": "python3 ./scripts/gen_sitemap.py",
     "docs:gen_alt_sidebar_ubuntu": "python3 ./scripts/gen_alt_sidebar.py",
     "docs:get_alt_sidebar_windows": "python ./scripts/gen_alt_sidebar.py",
     "start": "yarn docs:dev",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
-Allow: /
 
 Sitemap: https://mavlink.io/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://mavlink.io/sitemap.xml


### PR DESCRIPTION
## Problem
I had the issue quite often that when searching Google for e.g. "mavlink home position"  it surfaces https://mavlink.io/en/messages/common.html but links to the whole page rather than the relevant section (#HOME_POSITION). 
so i thought i gave it a shot to improve the crawling functionality for goodle, for it to mabye catch the section items, and link directly to there.

### disclaimer
i'm neither a webdev, not especially knowleable in SEO
This fix is generated by AI, so it might help. or might not. it most likely wont make it worse

## Solution

Config-only, low-risk changes (all server-rendered, so crawlable):

- Native VitePress sitemap (sitemap.xml at site root) + lastUpdated: true so entries carry <lastmod> freshness signals.
    [public/robots.txt](https://github.com/Claudio-Chies/mavlink-devguide/blob/claude/eager-knuth-u5a3hy/public/robots.txt) pointing crawlers at the sitemap.
- Per-page metadata via the existing transformPageData hook: a meaningful <meta name="description"> derived from the page title, plus OpenGraph tags and <link rel="canonical">.
- Removed the broken docs:sitemap script.

## Verification

`CI=true npm run docs:build` succeeds. 
The generated `dist/ `contains sitemap.xml (294 URLs, each with <lastmod>, including common.html), robots.txt at the root, and common.html with a per-page description, OG tags, and canonical — with the #HOME_POSITION anchors unchanged.

## Note

These changes improve crawling and snippet quality but won't force Google to deep-link to a specific section — that's algorithmic, and Google ignores URL fragments in sitemaps. The change most likely to make sections rank as their own results would be splitting the common.md into per-message pages, but i dont think this would be a way to go