### PR TITLE
Update heartbeat handling documentation

### DIFF
--- a/en/mavgen_python/index.md
+++ b/en/mavgen_python/index.md
@@ -158,8 +158,11 @@ the_connection = mavutil.mavlink_connection('udpin:localhost:14540')
 
 # Wait for the first heartbeat
 #   This sets the system and component ID of remote system for the link
-the_connection.wait_heartbeat()
-print("Heartbeat from system (system %u component %u)" % (the_connection.target_system, the_connection.target_component))
+hb = the_connection.wait_heartbeat()
+if hb is not None:
+   print("Heartbeat from system (system %u component %u)" % (the_connection.target_system, the_connection.target_component))
+else:
+   print("No heartbeat received")
 
 # Once connected, use 'the_connection' to get and send messages
 ```


### PR DESCRIPTION
mavlink_connection.wait_heartbeat() method does not error on timeout, it returns None mirroring recv_match()

The current documentation implies that the heartbeat is received as long as the method exits without error. 

This updates the handling of a None type to avoid silently accepting a timeout.