### PR TITLE
fix: use logical AND instead of bitwise AND in sidebar parser

### DIFF
--- a/.vitepress/get_sidebar.js
+++ b/.vitepress/get_sidebar.js
@@ -116,7 +116,7 @@ function parseGitbookSidebarToVuepress(sidebarContent, lang) {
       link_title = link_title.replace("\\_", "_");
 
       //set indent_divider level (easier to think in levels, numbers of zero prefixes)
-      if ((indent_divider == 0) & (indent_level > 0.0)) {
+      if ((indent_divider == 0) && (indent_level > 0.0)) {
         indent_divider = indent_level;
       }
       if (indent_divider > 0) {


### PR DESCRIPTION
## Summary
Fixes a bug in `.vitepress/get_sidebar.js` where a bitwise AND (`&`) was mistakenly used instead of a logical AND (`&&`) on line 119.

## Change
```diff
- if ((indent_divider == 0) & (indent_level > 0.0)) {
+ if ((indent_divider == 0) && (indent_level > 0.0)) {
```
