### PR TITLE
fix: correct MAV_CMD_PAYLOAD_CONTROL_DEPLOY link target

### DIFF
--- a/en/services/payload.md
+++ b/en/services/payload.md
@@ -59,7 +59,7 @@ These commands can be used to deploy a payload at a specific location, controlli
 **Implementations:**
 
 - [MAV_CMD_NAV_PAYLOAD_PLACE](#MAV_CMD_NAV_PAYLOAD_PLACE) is implemented in ArduPilot only, and can be used in missions.
-- [MAV_CMD_PAYLOAD_PREPARE_DEPLOY](../messages/common.md#MAV_CMD_PAYLOAD_PREPARE_DEPLOY) and [MAV_CMD_PAYLOAD_CONTROL_DEPLOY](../messages/common.md#MAV_CMD_PAYLOAD_PREPARE_DEPLOY) are not supported on any known flight stack.
+- [MAV_CMD_PAYLOAD_PREPARE_DEPLOY](../messages/common.md#MAV_CMD_PAYLOAD_PREPARE_DEPLOY) and [MAV_CMD_PAYLOAD_CONTROL_DEPLOY](../messages/common.md#MAV_CMD_PAYLOAD_CONTROL_DEPLOY) are not supported on any known flight stack.
   They are deprecated and should not be used.
 
 :::


### PR DESCRIPTION
## Summary
Fix a copy-paste error where MAV_CMD_PAYLOAD_CONTROL_DEPLOY incorrectly linked to the MAV_CMD_PAYLOAD_PREPARE_DEPLOY anchor.

## Change
`diff
-[MAV_CMD_PAYLOAD_CONTROL_DEPLOY](../messages/common.md#MAV_CMD_PAYLOAD_PREPARE_DEPLOY)
+[MAV_CMD_PAYLOAD_CONTROL_DEPLOY](../messages/common.md#MAV_CMD_PAYLOAD_CONTROL_DEPLOY)
` 

## Why this matters
Users clicking the MAV_CMD_PAYLOAD_CONTROL_DEPLOY link would previously land on the wrong command definition.
