### PR TITLE
XSD schema: isDestination/hasLocation

### DIFF
--- a/en/guide/xml_schema.md
+++ b/en/guide/xml_schema.md
@@ -139,7 +139,7 @@ For example, see [MAV_CMD_NAV_PAYLOAD_PLACE](../messages/common.md#MAV_CMD_NAV_P
 ```xml
 <enum name="MAV_CMD">
 ....
-      <entry value="94" name="MAV_CMD_NAV_PAYLOAD_PLACE" isDestination="true">
+      <entry value="94" name="MAV_CMD_NAV_PAYLOAD_PLACE" hasLocation="true" isDestination="true">
         <description>Descend and place payload. Vehicle moves to specified location, descends until it detects a hanging payload has reached the ground, and then releases the payload. If ground is not detected before the reaching the maximum descent value (param1), the command will complete without releasing the payload.</description>
         <param index="1" label="Max Descent" units="m" minValue="0">Maximum distance to descend.</param>
         <param index="2">Empty</param>
@@ -158,15 +158,12 @@ Attributes:
 - `name` (mandatory): The name of the command.
   This is a string of capitalized, underscore-separated words, prefixed with `MAV_CMD_`.
 - `value` (mandatory): The command number.
-- `missionOnly`: A boolean (default `false`). Apply with value `true` if the MAV_COMMAND only "makes sense" in a mission.
-  For example, the fence mission commands could not possibly be useful in a command.
-- One (but not both) of:
-  - `isDestination`: A boolean (default `false`) that provides a hint to a GCS that the entry is a location that should be displayed as a point on the flight path.
-    Apply for any MAV_CMDs that contain lat/lon/alt location information in params 5, 6, and 7, and that set a path/destination (e.g.: [MAV_CMD_NAV_WAYPOINT](../messages/common.md#MAV_CMD_NAV_WAYPOINT) and [MAV_CMD_NAV_LAND](../messages/common.md#MAV_CMD_NAV_LAND)).
-  - `hasLocation`: A boolean (default `false`) that provides a hint to a GCS that the entry contains a location that is not on the flight path, such as an ROI point.
-    Apply for MAV_CMDs that contain lat/lon/alt location information in params 5, 6, and 7 values but which are not on the vehicle path (e.g.: [MAV_CMD_DO_SET_ROI_LOCATION](../messages/common.md#MAV_CMD_DO_SET_ROI_LOCATION)).
-  - `hasAltitudeOnly`: A boolean (default `false`) that provides a hint to a GCS that the entry has an altitude but not position information (latitude or longitude).
-    Apply for MAV_CMD that contain altitude information in param 7 values but not latitude and longitude in params 5 and 6 (e.g.: [MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT](../messages/common.md#MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT)).
+- `hasLocation`: A boolean (default `false`) that indicates parm 5/6/7 contain lat/lon/alt information.
+- `isDestination`: A boolean (default `false`) that indicates whether an entry is on a flight path, such as [MAV_CMD_NAV_WAYPOINT](../messages/common.md#MAV_CMD_NAV_WAYPOINT) in a mission.
+  If `false` the entry is not a destination: it would be used for commands like [MAV_CMD_DO_SET_ROI_LOCATION](../messages/common.md#MAV_CMD_DO_SET_ROI_LOCATION).
+  `hasLocation` should be applied if this is `true`.
+- `hasAltitudeOnly`: A boolean (default `false`) that indicates the entry has altitude information in param 7 but no position information params 5 and 6 (e.g. [MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT](../messages/common.md#MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT)).
+  Mutually exclusive with `hasLocation`.
 
 Nested elements:
 


### PR DESCRIPTION
Following discussions in https://github.com/mavlink/mavlink/pull/2582 it is not possible to treat `isDestination` and `hasLocation` such that they are mutually exclusive without a long changover. This updates the docs to indicate that  `hasLocation`  indicates just "params contain location", while `isDestination` is what says the kind of location. So both must be applied.

Also removes the missionOnly.

FYI @peterbarker - as discussed!