### PR TITLE
Mission item - separate out to own doc

### DIFF
--- a/assets/protocols/mission_item_detail/gate_crossing.svg
+++ b/assets/protocols/mission_item_detail/gate_crossing.svg
@@ -3,17 +3,30 @@
     <marker id="arrow2" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
       <path d="M0,0 L8,3 L0,6 Z" fill="#2563eb"/>
     </marker>
+    <marker id="arrowGray" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#6b7280"/>
+    </marker>
   </defs>
 
   <rect x="0" y="0" width="640" height="340" fill="#ffffff"/>
 
-  <text x="320" y="24" text-anchor="middle" font-size="12" fill="#6b7280">the gate can sit off the route — the crossing is where its line meets the path</text>
-
-  <!-- gate line: perpendicular to the path, anchored at the gate's own position -->
-  <line x1="340" y1="120" x2="352" y2="270" stroke="#9ca3af" stroke-width="2" stroke-dasharray="6 5"/>
+  <text x="320" y="20" text-anchor="middle" font-size="12" fill="#6b7280">the trigger line passes through the gate, perpendicular to the GATE→NEXT WP direction —</text>
+  <text x="320" y="35" text-anchor="middle" font-size="12" fill="#6b7280">NOT perpendicular to the path itself</text>
 
   <!-- flight path: straight from prev destination to next, unaffected by the gate -->
   <path d="M80,260 L580,220" fill="none" stroke="#2563eb" stroke-width="3" marker-end="url(#arrow2)"/>
+
+  <!-- reference vector: gate -> next waypoint (this defines the trigger line's orientation) -->
+  <line x1="340" y1="120" x2="580" y2="220" stroke="#6b7280" stroke-width="2" stroke-dasharray="2 4" marker-end="url(#arrowGray)"/>
+  <text x="478" y="153" text-anchor="middle" font-size="12" fill="#6b7280" font-style="italic" transform="rotate(22 478 153)">gate → next wp</text>
+
+  <!-- trigger line: through the gate, perpendicular to gate->next wp (NOT to the path) -->
+  <line x1="355.4" y1="83.1" x2="272.7" y2="281.5" stroke="#f59e0b" stroke-width="2.5" stroke-dasharray="7 5"/>
+  <text x="230" y="105" text-anchor="middle" font-size="12" fill="#b45309" font-weight="bold">trigger line</text>
+  <text x="230" y="120" text-anchor="middle" font-size="11" fill="#b45309">(⊥ to gate→next wp)</text>
+
+  <!-- right-angle marker at the gate, between the reference vector and the trigger line -->
+  <path d="M334.6,132.9 L347.5,138.3 L352.9,125.4" fill="none" stroke="#6b7280" stroke-width="1.5"/>
 
   <!-- prev wp -->
   <circle cx="80" cy="260" r="5" fill="#111827"/>
@@ -23,14 +36,14 @@
   <circle cx="580" cy="220" r="5" fill="#111827"/>
   <text x="580" y="245" text-anchor="middle" font-size="13" fill="#111827">NEXT WP</text>
 
-  <!-- gate point: off the path; only anchors the line, it is not itself the trigger -->
+  <!-- gate point: off the path; anchors the trigger line, is not itself the trigger -->
   <circle cx="340" cy="120" r="5" fill="#111827"/>
   <text x="340" y="102" text-anchor="middle" font-size="14" fill="#111827" font-weight="bold">GATE</text>
 
-  <!-- reached: where the gate's line actually crosses the path -->
-  <circle cx="349.5" cy="238.4" r="9" fill="none" stroke="#dc2626" stroke-width="2"/>
-  <circle cx="349.5" cy="238.4" r="4" fill="#dc2626"/>
-  <line x1="357" y1="245" x2="420" y2="280" stroke="#dc2626" stroke-width="1.5"/>
-  <text x="425" y="278" font-size="13" fill="#dc2626" font-weight="bold">REACHED</text>
-  <text x="425" y="295" font-size="12" fill="#dc2626">crosses the line here</text>
+  <!-- reached: where the trigger line actually crosses the path -->
+  <circle cx="288.6" cy="243.3" r="9" fill="none" stroke="#dc2626" stroke-width="2"/>
+  <circle cx="288.6" cy="243.3" r="4" fill="#dc2626"/>
+  <line x1="282" y1="251" x2="230" y2="285" stroke="#dc2626" stroke-width="1.5"/>
+  <text x="225" y="298" text-anchor="end" font-size="13" fill="#dc2626" font-weight="bold">REACHED</text>
+  <text x="225" y="313" text-anchor="end" font-size="12" fill="#dc2626">crosses the trigger line here</text>
 </svg>

--- a/assets/protocols/mission_item_detail/gate_crossing.svg
+++ b/assets/protocols/mission_item_detail/gate_crossing.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="255" viewBox="0 0 640 340" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow2" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#2563eb"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="640" height="340" fill="#ffffff"/>
+
+  <text x="320" y="24" text-anchor="middle" font-size="12" fill="#6b7280">the gate can sit off the route — the crossing is where its line meets the path</text>
+
+  <!-- gate line: perpendicular to the path, anchored at the gate's own position -->
+  <line x1="340" y1="120" x2="352" y2="270" stroke="#9ca3af" stroke-width="2" stroke-dasharray="6 5"/>
+
+  <!-- flight path: straight from prev destination to next, unaffected by the gate -->
+  <path d="M80,260 L580,220" fill="none" stroke="#2563eb" stroke-width="3" marker-end="url(#arrow2)"/>
+
+  <!-- prev wp -->
+  <circle cx="80" cy="260" r="5" fill="#111827"/>
+  <text x="80" y="285" text-anchor="middle" font-size="13" fill="#111827">PREV WP</text>
+
+  <!-- next wp -->
+  <circle cx="580" cy="220" r="5" fill="#111827"/>
+  <text x="580" y="245" text-anchor="middle" font-size="13" fill="#111827">NEXT WP</text>
+
+  <!-- gate point: off the path; only anchors the line, it is not itself the trigger -->
+  <circle cx="340" cy="120" r="5" fill="#111827"/>
+  <text x="340" y="102" text-anchor="middle" font-size="14" fill="#111827" font-weight="bold">GATE</text>
+
+  <!-- reached: where the gate's line actually crosses the path -->
+  <circle cx="349.5" cy="238.4" r="9" fill="none" stroke="#dc2626" stroke-width="2"/>
+  <circle cx="349.5" cy="238.4" r="4" fill="#dc2626"/>
+  <line x1="357" y1="245" x2="420" y2="280" stroke="#dc2626" stroke-width="1.5"/>
+  <text x="425" y="278" font-size="13" fill="#dc2626" font-weight="bold">REACHED</text>
+  <text x="425" y="295" font-size="12" fill="#dc2626">crosses the line here</text>
+</svg>

--- a/assets/protocols/mission_item_detail/pass_radius_fillet.svg
+++ b/assets/protocols/mission_item_detail/pass_radius_fillet.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="210" viewBox="0 0 640 280" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow4" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#2563eb"/>
+    </marker>
+    <marker id="arrow4g" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#9ca3af"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="640" height="280" fill="#ffffff"/>
+
+  <!-- straight-through path (radius = 0) -->
+  <path d="M80,60 L340,220 L580,60" fill="none" stroke="#9ca3af" stroke-width="2.5" stroke-dasharray="6 5" marker-end="url(#arrow4g)"/>
+  <text x="365" y="240" font-size="13" fill="#6b7280">0: straight through</text>
+
+  <!-- fillet path (+r, CW), cuts inside the corner via a rounding arc -->
+  <path d="M80,60 L280.4,183.3 Q340,220 398.2,181.1 L580,60" fill="none" stroke="#2563eb" stroke-width="3" marker-end="url(#arrow4)"/>
+  <text x="415" y="150" font-size="13" fill="#1d4ed8" font-weight="bold">+r, CW</text>
+
+  <!-- corner / waypoint marker -->
+  <circle cx="340" cy="220" r="5" fill="#111827"/>
+
+  <!-- prev / next -->
+  <circle cx="80" cy="60" r="5" fill="#111827"/>
+  <text x="80" y="42" text-anchor="middle" font-size="13" fill="#111827">PREV WP</text>
+  <circle cx="580" cy="60" r="5" fill="#111827"/>
+  <text x="580" y="42" text-anchor="middle" font-size="13" fill="#111827">NEXT WP</text>
+
+  <!-- radius annotation -->
+  <line x1="340" y1="220" x2="280.4" y2="183.3" stroke="#dc2626" stroke-width="1.5" stroke-dasharray="3 3"/>
+  <text x="280" y="215" text-anchor="end" font-size="12" fill="#dc2626">radius = |param 3|</text>
+  <text x="280" y="230" text-anchor="end" font-size="12" fill="#dc2626">sign picks CW / CCW</text>
+</svg>

--- a/assets/protocols/mission_item_detail/waypoint_accept_radius.svg
+++ b/assets/protocols/mission_item_detail/waypoint_accept_radius.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="240" viewBox="0 -20 640 320" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrow1" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#2563eb"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="-20" width="640" height="320" fill="#ffffff"/>
+
+  <!-- accept radius circle -->
+  <circle cx="340" cy="80" r="85" fill="none" stroke="#9ca3af" stroke-width="2" stroke-dasharray="6 5"/>
+  <text x="340" y="185" text-anchor="middle" font-size="13" fill="#6b7280">r = Accept Radius (param 2)</text>
+
+  <!-- flight path: prev -> waypoint (as bezier apex) -> next -->
+  <path d="M80,260 Q340,80 580,220" fill="none" stroke="#2563eb" stroke-width="3" marker-end="url(#arrow1)"/>
+
+  <!-- waypoint marker -->
+  <circle cx="340" cy="80" r="5" fill="#111827"/>
+  <text x="340" y="60" text-anchor="middle" font-size="14" fill="#111827" font-weight="bold">WAYPOINT</text>
+
+  <!-- prev wp -->
+  <circle cx="80" cy="260" r="5" fill="#111827"/>
+  <text x="80" y="285" text-anchor="middle" font-size="13" fill="#111827">PREV WP</text>
+
+  <!-- next wp -->
+  <circle cx="580" cy="220" r="5" fill="#111827"/>
+  <text x="580" y="245" text-anchor="middle" font-size="13" fill="#111827">NEXT WP</text>
+
+  <!-- reached marker -->
+  <circle cx="315" cy="162" r="6" fill="#dc2626"/>
+  <line x1="315" y1="162" x2="230" y2="230" stroke="#dc2626" stroke-width="1.5"/>
+  <text x="150" y="245" text-anchor="middle" font-size="13" fill="#dc2626" font-weight="bold">REACHED</text>
+  <text x="150" y="262" text-anchor="middle" font-size="12" fill="#dc2626">enters accept radius here</text>
+</svg>

--- a/assets/protocols/mission_item_detail/waypoint_yaw.svg
+++ b/assets/protocols/mission_item_detail/waypoint_yaw.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="210" viewBox="0 0 640 280" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arrowY1" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#2563eb"/>
+    </marker>
+    <marker id="arrowY2" markerWidth="10" markerHeight="10" refX="7" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L8,3 L0,6 Z" fill="#ea580c"/>
+    </marker>
+  </defs>
+
+  <rect x="0" y="0" width="640" height="280" fill="#ffffff"/>
+
+  <!-- next wp + connector -->
+  <line x1="160" y1="200" x2="560" y2="70" stroke="#d1d5db" stroke-width="1.5" stroke-dasharray="4 4"/>
+  <circle cx="560" cy="70" r="5" fill="#111827"/>
+  <text x="560" y="55" text-anchor="middle" font-size="13" fill="#111827">NEXT WP</text>
+
+  <!-- north reference -->
+  <line x1="160" y1="200" x2="160" y2="140" stroke="#9ca3af" stroke-width="1.5" stroke-dasharray="3 3"/>
+  <text x="160" y="130" text-anchor="middle" font-size="12" fill="#9ca3af">N</text>
+
+  <!-- yaw = NaN, faces next waypoint -->
+  <line x1="160" y1="200" x2="369" y2="132" stroke="#ea580c" stroke-width="3" stroke-dasharray="7 5" marker-end="url(#arrowY2)"/>
+  <text x="390" y="120" font-size="13" fill="#c2410c" font-weight="bold">Yaw = NaN: faces next WP</text>
+
+  <!-- fixed yaw = 90 -->
+  <line x1="160" y1="200" x2="355" y2="200" stroke="#2563eb" stroke-width="3" marker-end="url(#arrowY1)"/>
+
+  <!-- waypoint marker -->
+  <circle cx="160" cy="200" r="5" fill="#111827"/>
+
+  <!-- point labels, single row -->
+  <text x="160" y="225" text-anchor="middle" font-size="13" fill="#111827">WAYPOINT</text>
+  <text x="300" y="225" font-size="13" fill="#1d4ed8" font-weight="bold">Yaw = 90°: fixed heading</text>
+</svg>

--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -43,6 +43,7 @@
 - [Microservices](services/index.md)
   - [Heartbeat/Connection Protocol](services/heartbeat.md)
   - [Mission Protocol](services/mission.md)
+    - [Mission Item Detail](services/mission_item_detail.md)
   - [Parameter Protocol](services/parameter.md)
   - [Extended Parameter Protocol](services/parameter_ext.md)
   - [Command Protocol](services/command.md)

--- a/en/services/mission.md
+++ b/en/services/mission.md
@@ -12,6 +12,8 @@ The protocol covers:
 
 The protocol supports re-request of messages that have not arrived, which allows missions to be reliably transferred over a lossy link.
 
+See [Mission Item Detail](mission_item_detail.md) for information about specific MAV_CMD that can be used within a mission.
+
 ## Plan Types {#mission_types}
 
 The protocols supports the uploading and downloading of three types of plan: flight plans ("missions"), geofence plans, and rally/safe points plans.
@@ -401,71 +403,6 @@ GCS/developer API can monitor progress by handling the appropriate messages sent
 ## Mission File Formats
 
 The _defacto_ standard file format for exchanging missions/plans is discussed in: [File Formats > Mission Plain-Text File Format](../file_formats/index.md#mission_plain_text_file).
-
-## Mission Command Detail
-
-This section is for clarifications and additional information about common mission items.
-In particular it is intended for cases that are difficult to document in the specification XML, or when images will much better describe expected behaviour.
-
-### Loiter Commands (`MAV_CMD_NAV_LOITER_*`) {#loiter_commands}
-
-Loiter commands are provided to allow a vehicle to hold at a location for a specified time or number of turns, until it reaches the specified altitude, or indefinitely.
-Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
-Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
-
-The commands are:
-
-- [MAV_CMD_NAV_LOITER_TIME](../messages/common.md#MAV_CMD_NAV_LOITER_TIME) - Loiter at specified location for a given amount of time after reaching the location.
-- [MAV_CMD_NAV_LOITER_TURNS](../messages/common.md#MAV_CMD_NAV_LOITER_TURNS) - Loiter at specified location for a given number of turns.
-- [MAV_CMD_NAV_LOITER_TO_ALT](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TO_ALT) - Loiter at specified location until desired altitude is reached.
-- [MAV_CMD_NAV_LOITER_UNLIM](../messages/common.md#MAV_CMD_NAV_LOITER_UNLIM) - Loiter at specified location for an unlimited amount of time, yawing to face a given direction.
-
-The location and fixed-wing loiter radius parameters are common to all commands:
-
-| Param (:Label) | Description                                                                  | Units |
-| -------------- | ---------------------------------------------------------------------------- | ----- |
-| 3: Radius      | Radius around waypoint. If positive loiter clockwise, else counter-clockwise | m     |
-| 5: Latitude    | Latitude                                                                     |
-| 6: Longitude   | Longitude                                                                    |
-| 7: Altitude    | Altitude                                                                     | m     |
-
-The loiter time and turns are set in param 1 for the respective messages.
-The direction of loiter for `MAV_CMD_NAV_LOITER_UNLIM` can be set using `param4` (Yaw).
-
-::: info
-The remaining parameters (xtrack and heading) apply only to forward flying aircraft (not multicopters!)
-:::
-
-Xtrack and heading define the location at which a forward flying (fixed wing) vehicle will _exit the loiter circle, and its path to the next waypoint_ (these apply only to `MAV_CMD_NAV_LOITER_TIME` and `MAV_CMD_NAV_LOITER_TURNS`).
-
-| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                             | Units                   |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False)                                                                                                                                                                                                                                                                                             | min:0 max:1 increment:1 |
-| 4: Xtrack Location  | Sets xtrack path or exit location: `0` for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), `1` to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. |
-
-The recommended values (and resulting paths) are those shown below.
-
-![Loiter heading](../../assets/protocols/mission_loiter/xtrack1_0_heading_1.png)
-
-The vehicle leaves the loiter after it reaches the desired number of turns or time _and_ based on **both** the `heading required` and `xtrack` params.
-
-A `heading required` of `1` prevents the vehicle from exiting the loiter unless it is heading towards the next waypoint (if `0` it can leave at any point provided the other conditions are met).
-With this setting the vehicle can leave at any point in the arc shown, provided it meets the other conditions (e.g. xtrack).
-If necessary (i.e. it is not in the arc when the other conditions are met), the vehicle will loop back around the loiter before it evaluates the xtrack condition.
-
-![Loiter heading](../../assets/protocols/mission_loiter/xtrack_heading.png)
-
-The Xtrack parameter independently defines the path and exit location:
-
-- `xtrack=0`: Exit the loiter circle and converge to the centre xtrack between this and the next waypoint.
-  - If the heading required parameter is not set it will exit the loiter immediately.
-  - Otherwise it will leave as soon as it is heading towards the next waypoint (which may also be immediately!)
-- `xtrack=1`: Exit the loiter circle and fly/converge to the straight line between the exit point and the centre of the next waypoint (i.e. don't converge to the centre xtrack).
-  - If the heading required parameter is set it will exit the loiter as soon as it is heading towards the next waypoint (which may be immediately!).
-  - If the heading required parameter is not set it will exit the loiter immediately (note that this exit path does not make much sense unless the heading parameter is set).
-- `xtrack=NaN`: Exit the loiter using "system specific default behaviour".
-  - The vehicle must still respect the heading required param.
-  - Usually this is synonymous with `xtrack=0`
 
 ## Implementations
 

--- a/en/services/mission_item_detail.md
+++ b/en/services/mission_item_detail.md
@@ -52,7 +52,8 @@ If you need an exact, turn-independent trigger point (for example a survey-edge 
 
 ArduPilot:
 
-- _Pass Radius_ (param3) implemented only on ArduPlane. It doesn't curve the flight path — it moves the acceptance point further out along the inbound course, so the corner is still flown straight, just cut sooner.
+- _Pass Radius_ (param3) implemented only on ArduPlane.
+  It doesn't curve the flight path — it moves the acceptance point further out along the inbound course, so the corner is still flown straight, just cut sooner.
   Other vehicle types ignore it.
 
 PX4:
@@ -61,7 +62,7 @@ PX4:
 
 ### MAV_CMD_NAV_LOITER_TIME {#MAV_CMD_NAV_LOITER_TIME}
 
-[MAV_CMD_NAV_LOITER_TIME](../messages/common.md#MAV_CMD_NAV_LOITER_TIME) - Loiter at specified location for a given amount of time after reaching the location.
+[MAV_CMD_NAV_LOITER_TIME](../messages/common.md#MAV_CMD_NAV_LOITER_TIME) causes a vehicle to loiter at specified location for a given amount of time after reaching the location.
 
 Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
 Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
@@ -110,12 +111,18 @@ The Xtrack parameter independently defines the path and exit location:
   - The vehicle must still respect the heading required param.
   - Usually this is synonymous with `xtrack=0`
 
+<!--
+#### Autopilot Support
+
+- Untested
+-->
+
 ### MAV_CMD_NAV_LOITER_TURNS {#MAV_CMD_NAV_LOITER_TURNS}
 
-[MAV_CMD_NAV_LOITER_TURNS](../messages/common.md#MAV_CMD_NAV_LOITER_TURNS) - Loiter at specified location for a given number of turns.
+[MAV_CMD_NAV_LOITER_TURNS](../messages/common.md#MAV_CMD_NAV_LOITER_TURNS) causes a vehicle to loiter at specified location for a given number of turns.
 
-Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
 Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
+Multicopter vehicles should similarly circle at the specified radius/direction.
 
 #### Params
 
@@ -131,22 +138,30 @@ Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified 
 
 ### MAV_CMD_NAV_LOITER_TO_ALT {#MAV_CMD_NAV_LOITER_TO_ALT}
 
-[MAV_CMD_NAV_LOITER_TO_ALT](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TO_ALT) - Loiter at specified location until desired altitude is reached.
+[MAV_CMD_NAV_LOITER_TO_ALT](../messages/common.md#MAV_CMD_NAV_LOITER_TO_ALT) causes the vehicle to loiter at specified location until desired altitude is reached.
 
-Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
+Multicopter vehicles stop at the specified location and altitude (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
 Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
 
 #### Params
 
-| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                               | Units                |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| 1: Heading Required | Leave loiter circle only when track heading towards the next waypoint (MAV_BOOL_TRUE). A value of MAV_BOOL_FALSE causes leaving when altitude is reached. Values not equal to 0 or 1 are invalid.                                                                                                                                                                                                                                                         |                      |
-| 2: Radius           | Radius around waypoint. If positive loiter clockwise, else counter-clockwise                                                                                                                                                                                                                                                                                                                                                                              | m                    |
-| 3                   | Empty                                                                                                                                                                                                                                                                                                                                                                                                                                                     |                      |
-| 4: Xtrack Location  | Loiter circle exit location and/or path to next waypoint ("xtrack") for forward-only moving vehicles (not multicopters). 0 for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), 1 to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. | min: 0 max: 1 inc: 1 |
-| 5: Latitude         | Latitude                                                                                                                                                                                                                                                                                                                                                                                                                                                  |                      |
-| 6: Longitude        | Longitude                                                                                                                                                                                                                                                                                                                                                                                                                                                 |                      |
-| 7: Altitude         | Altitude                                                                                                                                                                                                                                                                                                                                                                                                                                                  | m                    |
+NOTE: Param order differs from the other loiter commands here: Heading Required is param 1 and Radius is param 2, not param 2/3.
+
+| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Units                |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| 1: Heading Required | Leave loiter circle only when track heading towards the next waypoint (MAV_BOOL_TRUE). A value of MAV_BOOL_FALSE causes leaving when altitude is reached. Values not equal to 0 or 1 are invalid. See [Exit Conditions](#loiter_exit) above.                                                                                                                                                                                                                                                         |                      |
+| 2: Radius           | Radius around waypoint. If positive loiter clockwise, else counter-clockwise; `0` means no change to the standard loiter radius.                                                                                                                                                                                                                                                                                                                                                                     | m                    |
+| 3                   | Empty                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |                      |
+| 4: Xtrack Location  | Loiter circle exit location and/or path to next waypoint ("xtrack") for forward-only moving vehicles (not multicopters). 0 for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), 1 to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. See [Exit Conditions](#loiter_exit) above. | min: 0 max: 1 inc: 1 |
+| 5: Latitude         | Latitude (`0` with Longitude `0` means loiter at the current position).                                                                                                                                                                                                                                                                                                                                                                                                                              |                      |
+| 6: Longitude        | Longitude (`0` with Latitude `0` means loiter at the current position).                                                                                                                                                                                                                                                                                                                                                                                                                              |                      |
+| 7: Altitude         | Target altitude — the loiter is not complete until this is reached.                                                                                                                                                                                                                                                                                                                                                                                                                                  | m                    |
+
+<!--
+#### Autopilot support
+
+- Untested
+-->
 
 ### MAV_CMD_NAV_LOITER_UNLIM {#MAV_CMD_NAV_LOITER_UNLIM}
 

--- a/en/services/mission_item_detail.md
+++ b/en/services/mission_item_detail.md
@@ -189,25 +189,26 @@ Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified 
 
 ### MAV_CMD_CONDITION_GATE {#condition_gate}
 
-[MAV_CMD_CONDITION_GATE](../messages/common.md#MAV_CMD_CONDITION_GATE) (id 4501) marks an off-path location (not a destination) that indirectly defines where on the path to the _next_ waypoint the condition is accepted.
+[MAV_CMD_CONDITION_GATE](../messages/common.md#MAV_CMD_CONDITION_GATE) (id 4501) marks an off-path location (not a destination) that defines a trigger point somewhere along the path to the _next_ waypoint.
 
 When the gate is reached, the vehicle flies directly towards the _next_ mission item that is on the path (such as a waypoint).
-The mission state machine is blocked on the gate mission item until the vehicle reaches the point on the path that is perpendicular to the gate location.
+The mission state machine is blocked on the gate mission item until the vehicle crosses the **trigger line**: the line through the gate's own position, perpendicular to the direction _from the gate to the next waypoint_.
+Because that reference direction isn't the path direction, an off-path gate's actual trigger point is shifted from where a simple "project the gate straight onto the path" calculation would suggest — see the diagram.
 This can be used for triggering a `DO_*` action (camera, speed change, etc.) at a precise point along a leg, without affecting the route itself.
 
-![The vehicle flies straight from the previous destination to the next; the gate sits off that path, and the trigger fires where its line crosses the path](../../assets/protocols/mission_item_detail/gate_crossing.svg)
+![The vehicle flies straight from the previous destination to the next; the trigger line runs through the gate, perpendicular to the gate→next-waypoint direction, and fires where that line crosses the path](../../assets/protocols/mission_item_detail/gate_crossing.svg)
 
 #### Params
 
-| Param (:Label) | Description                                                                                    | Units |
-| -------------- | ---------------------------------------------------------------------------------------------- | ----- |
-| 1: Geometry    | Geometry of the gate test. `0`: line orthogonal to the path (no other values defined/allowed). |       |
-| 2: UseAltitude | [MAV_BOOL_TRUE](../messages/common.md#MAV_BOOL) if altitude is included in the crossing test.  |       |
-| 3              | -                                                                                              |       |
-| 4              | -                                                                                              |       |
-| 5: Latitude    | Latitude of the gate.                                                                          |       |
-| 6: Longitude   | Longitude of the gate.                                                                         |       |
-| 7: Altitude    | Altitude of the gate.                                                                          | m     |
+| Param (:Label) | Description                                                                                                                              | Units |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| 1: Geometry    | Geometry of the gate test. `0`: line through the gate, orthogonal to the gate→next-waypoint direction (no other values defined/allowed). |       |
+| 2: UseAltitude | [MAV_BOOL_TRUE](../messages/common.md#MAV_BOOL) if altitude is included in the crossing test.                                            |       |
+| 3              | -                                                                                                                                        |       |
+| 4              | -                                                                                                                                        |       |
+| 5: Latitude    | Latitude of the gate.                                                                                                                    |       |
+| 6: Longitude   | Longitude of the gate.                                                                                                                   |       |
+| 7: Altitude    | Altitude of the gate.                                                                                                                    | m     |
 
 #### Autopilot Support
 

--- a/en/services/mission_item_detail.md
+++ b/en/services/mission_item_detail.md
@@ -1,0 +1,96 @@
+# Mission Item Detail
+
+This page is for clarifications and additional information about common mission items ("MAV_CMD"s used in [plans](mission.md#mavlink_commands)).
+In particular it is intended for cases that are difficult to document in the specification XML, or when images will much better describe expected behaviour.
+
+## `NAV_` Items
+
+Navigation items typically have the prefix `MAV_CMD_NAV_`.
+These define positions that are destinations on the path.
+
+### MAV_CMD_NAV_WAYPOINT {#nav_waypoint}
+
+[MAV_CMD_NAV_WAYPOINT](../messages/common.md#MAV_CMD_NAV_WAYPOINT) represents a basic waypoint/destination in a mission.
+As a destination item, it always requires a position (params 5–7) to say where "this point" is.
+
+It is considered **reached** the instant the vehicle enters a sphere of radius _Accept Radius_ (param 2) around the point.
+The vehicle may "cut the corner" as shown below.
+
+![A waypoint triggers on distance to the point, not on reaching the point itself](../../assets/protocols/mission_item_detail/waypoint_accept_radius.svg)
+
+#### Params
+
+| Param (:Label)   | Description                                                                      |
+| ---------------- | -------------------------------------------------------------------------------- |
+| 1: Hold          | Hold time (ignored by fixed-wing; time to stay at the waypoint for rotary-wing). |
+| 2: Accept Radius | Acceptance radius — the "reached" trigger described above.                       |
+| 3: Pass Radius   | Corner-shaping only — see [Pass Radius](#pass_radius) below.                     |
+| 4: Yaw           | Heading at the waypoint (rotary-wing only) or NaN. See [Yaw](#yaw).              |
+| 5: Latitude      | Latitude of the waypoint (required).                                             |
+| 6: Longitude     | Longitude of the waypoint (required).                                            |
+| 7: Altitude      | Altitude of the waypoint (required).                                             |
+
+Neither flight stack validates altitude — an unset (`NaN`) value isn't rejected, it's simply copied into the navigation setpoint as-is. So it doesn't fail cleanly, it just doesn't do what you intended: always send a real value.
+
+#### Yaw (heading at the waypoint) {#yaw}
+
+Param 4 (_Yaw_) sets the vehicle's desired heading once it reaches the point (an absolute compass angle).
+It only applies to rotary-wing vehicles.
+`NaN` leaves it to a system-wide default heading behaviour (PX4: `MPC_YAW_MODE`; ArduPilot: `WP_YAW_BEHAVIOR`) — normally to face the next waypoint.
+
+![Yaw sets a fixed heading; NaN faces the next waypoint instead](../../assets/protocols/mission_item_detail/waypoint_yaw.svg)
+
+#### Pass Radius (Corner Shaping) {#pass_radius}
+
+Param 3 (_Pass Radius_) shapes the turn: `0` flies straight through the point; a non-zero value flies by, offset up to that radius, rounding the corner (sign selects clockwise/counter-clockwise).
+
+![Pass Radius shapes the corner; it does not move the accept-radius trigger](../../assets/protocols/mission_item_detail/pass_radius_fillet.svg)
+
+If you need an exact, turn-independent trigger point (for example a survey-edge camera trigger) use [MAV_CMD_CONDITION_GATE](#condition_gate).
+
+#### Autopilot Support
+
+ArduPilot:
+
+- _Pass Radius_ (param3) implemented only on ArduPlane. It doesn't curve the flight path — it moves the acceptance point further out along the inbound course, so the corner is still flown straight, just cut sooner.
+  Other vehicle types ignore it.
+
+PX4:
+
+- _Pass Radius_ (param3) not implemented. A non-default value for param 3 is rejected.
+
+## `CONDITION_` Items
+
+### MAV_CMD_CONDITION_GATE {#condition_gate}
+
+[MAV_CMD_CONDITION_GATE](../messages/common.md#MAV_CMD_CONDITION_GATE) (id 4501) marks an off-path location (not a destination) that indirectly defines where on the path to the _next_ waypoint the condition is accepted.
+
+When the gate is reached, the vehicle flies directly towards the _next_ mission item that is on the path (such as a waypoint).
+The mission state machine is blocked on the gate mission item until the vehicle reaches the point on the path that is perpendicular to the gate location.
+This can be used for triggering a `DO_*` action (camera, speed change, etc.) at a precise point along a leg, without affecting the route itself.
+
+![The vehicle flies straight from the previous destination to the next; the gate sits off that path, and the trigger fires where its line crosses the path](../../assets/protocols/mission_item_detail/gate_crossing.svg)
+
+#### Params
+
+| Param (:Label) | Description                                                                                    |
+| -------------- | ---------------------------------------------------------------------------------------------- |
+| 1: Geometry    | Geometry of the gate test. `0`: line orthogonal to the path (no other values defined/allowed). |
+| 2: UseAltitude | [MAV_BOOL_TRUE](../messages/common.md#MAV_BOOL) if altitude is included in the crossing test.  |
+| 3:             |                                                                                                |
+| 4:             |                                                                                                |
+| 5: Latitude    | Latitude of the gate.                                                                          |
+| 6: Longitude   | Longitude of the gate.                                                                         |
+| 7: Altitude    | Altitude of the gate.                                                                          |
+
+#### Autopilot support
+
+ArduPilot:
+
+- Not supported. See [ardupilot#13778](https://github.com/ArduPilot/ardupilot/issues/13778).
+
+PX4:
+
+- Supported from PX4v1.11
+- `UseAltitude` field ignored (geometry test is 2D)
+- A gate within 5 cm of a neighboring waypoint is rejected as infeasible.

--- a/en/services/mission_item_detail.md
+++ b/en/services/mission_item_detail.md
@@ -59,6 +59,66 @@ PX4:
 
 - _Pass Radius_ (param3) not implemented. A non-default value for param 3 is rejected.
 
+### Loiter Commands (`MAV_CMD_NAV_LOITER_*`) {#loiter_commands}
+
+Loiter commands are provided to allow a vehicle to hold at a location for a specified time or number of turns, until it reaches the specified altitude, or indefinitely.
+Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
+Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
+
+The commands are:
+
+- [MAV_CMD_NAV_LOITER_TIME](../messages/common.md#MAV_CMD_NAV_LOITER_TIME) - Loiter at specified location for a given amount of time after reaching the location.
+- [MAV_CMD_NAV_LOITER_TURNS](../messages/common.md#MAV_CMD_NAV_LOITER_TURNS) - Loiter at specified location for a given number of turns.
+- [MAV_CMD_NAV_LOITER_TO_ALT](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TO_ALT) - Loiter at specified location until desired altitude is reached.
+- [MAV_CMD_NAV_LOITER_UNLIM](../messages/common.md#MAV_CMD_NAV_LOITER_UNLIM) - Loiter at specified location for an unlimited amount of time, yawing to face a given direction.
+
+The location and fixed-wing loiter radius parameters are common to all commands:
+
+| Param (:Label) | Description                                                                  | Units |
+| -------------- | ---------------------------------------------------------------------------- | ----- |
+| 3: Radius      | Radius around waypoint. If positive loiter clockwise, else counter-clockwise | m     |
+| 5: Latitude    | Latitude                                                                     |
+| 6: Longitude   | Longitude                                                                    |
+| 7: Altitude    | Altitude                                                                     | m     |
+
+The loiter time and turns are set in param 1 for the respective messages.
+The direction of loiter for `MAV_CMD_NAV_LOITER_UNLIM` can be set using `param4` (Yaw).
+
+::: info
+The remaining parameters (xtrack and heading) apply only to forward flying aircraft (not multicopters!)
+:::
+
+Xtrack and heading define the location at which a forward flying (fixed wing) vehicle will _exit the loiter circle, and its path to the next waypoint_ (these apply only to `MAV_CMD_NAV_LOITER_TIME` and `MAV_CMD_NAV_LOITER_TURNS`).
+
+| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                             | Units                   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False)                                                                                                                                                                                                                                                                                             | min:0 max:1 increment:1 |
+| 4: Xtrack Location  | Sets xtrack path or exit location: `0` for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), `1` to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. |
+
+The recommended values (and resulting paths) are those shown below.
+
+![Loiter heading](../../assets/protocols/mission_loiter/xtrack1_0_heading_1.png)
+
+The vehicle leaves the loiter after it reaches the desired number of turns or time _and_ based on **both** the `heading required` and `xtrack` params.
+
+A `heading required` of `1` prevents the vehicle from exiting the loiter unless it is heading towards the next waypoint (if `0` it can leave at any point provided the other conditions are met).
+With this setting the vehicle can leave at any point in the arc shown, provided it meets the other conditions (e.g. xtrack).
+If necessary (i.e. it is not in the arc when the other conditions are met), the vehicle will loop back around the loiter before it evaluates the xtrack condition.
+
+![Loiter heading](../../assets/protocols/mission_loiter/xtrack_heading.png)
+
+The Xtrack parameter independently defines the path and exit location:
+
+- `xtrack=0`: Exit the loiter circle and converge to the centre xtrack between this and the next waypoint.
+  - If the heading required parameter is not set it will exit the loiter immediately.
+  - Otherwise it will leave as soon as it is heading towards the next waypoint (which may also be immediately!)
+- `xtrack=1`: Exit the loiter circle and fly/converge to the straight line between the exit point and the centre of the next waypoint (i.e. don't converge to the centre xtrack).
+  - If the heading required parameter is set it will exit the loiter as soon as it is heading towards the next waypoint (which may be immediately!).
+  - If the heading required parameter is not set it will exit the loiter immediately (note that this exit path does not make much sense unless the heading parameter is set).
+- `xtrack=NaN`: Exit the loiter using "system specific default behaviour".
+  - The vehicle must still respect the heading required param.
+  - Usually this is synonymous with `xtrack=0`
+
 ## `CONDITION_` Items
 
 ### MAV_CMD_CONDITION_GATE {#condition_gate}

--- a/en/services/mission_item_detail.md
+++ b/en/services/mission_item_detail.md
@@ -1,7 +1,7 @@
 # Mission Item Detail
 
 This page is for clarifications and additional information about common mission items ("MAV_CMD"s used in [plans](mission.md#mavlink_commands)).
-In particular it is intended for cases that are difficult to document in the specification XML, or when images will much better describe expected behaviour.
+In particular it is intended for cases that are difficult to document in the specification XML, or when an image better describes expected behaviour.
 
 ## `NAV_` Items
 
@@ -20,17 +20,17 @@ The vehicle may "cut the corner" as shown below.
 
 #### Params
 
-| Param (:Label)   | Description                                                                      |
-| ---------------- | -------------------------------------------------------------------------------- |
-| 1: Hold          | Hold time (ignored by fixed-wing; time to stay at the waypoint for rotary-wing). |
-| 2: Accept Radius | Acceptance radius — the "reached" trigger described above.                       |
-| 3: Pass Radius   | Corner-shaping only — see [Pass Radius](#pass_radius) below.                     |
-| 4: Yaw           | Heading at the waypoint (rotary-wing only) or NaN. See [Yaw](#yaw).              |
-| 5: Latitude      | Latitude of the waypoint (required).                                             |
-| 6: Longitude     | Longitude of the waypoint (required).                                            |
-| 7: Altitude      | Altitude of the waypoint (required).                                             |
+| Param (:Label)   | Description                                                                                                                                                       | Units |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| 1: Hold          | Hold time (ignored by fixed-wing; time to stay at the waypoint for rotary-wing).                                                                                  | s     |
+| 2: Accept Radius | Acceptance radius — the "reached" trigger described above.                                                                                                        | m     |
+| 3: Pass Radius   | 0 to pass through the WP, if > 0 radius to pass by WP. Positive value for clockwise orbit, negative value for counter-clockwise orbit. Allows trajectory control. | m     |
+| 4: Yaw           | Heading at the waypoint (rotary-wing only) or NaN. See [Yaw](#yaw).                                                                                               | deg   |
+| 5: Latitude      | Latitude of the waypoint (required).                                                                                                                              |       |
+| 6: Longitude     | Longitude of the waypoint (required).                                                                                                                             |       |
+| 7: Altitude      | Altitude of the waypoint (required).                                                                                                                              | m     |
 
-Neither flight stack validates altitude — an unset (`NaN`) value isn't rejected, it's simply copied into the navigation setpoint as-is. So it doesn't fail cleanly, it just doesn't do what you intended: always send a real value.
+<!-- TBD: TO VERIFY — Neither flight stack validates altitude; an unset (`NaN`) value is copied into the navigation setpoint as-is, so it doesn't fail cleanly, it just doesn't do what you intended. Always send a real value. -->
 
 #### Yaw (heading at the waypoint) {#yaw}
 
@@ -39,6 +39,8 @@ It only applies to rotary-wing vehicles.
 `NaN` leaves it to a system-wide default heading behaviour (PX4: `MPC_YAW_MODE`; ArduPilot: `WP_YAW_BEHAVIOR`) — normally to face the next waypoint.
 
 ![Yaw sets a fixed heading; NaN faces the next waypoint instead](../../assets/protocols/mission_item_detail/waypoint_yaw.svg)
+
+<!-- TBD: To verify - from Claude
 
 #### Pass Radius (Corner Shaping) {#pass_radius}
 
@@ -60,6 +62,8 @@ PX4:
 
 - _Pass Radius_ (param3) not implemented. A non-default value for param 3 is rejected.
 
+-->
+
 ### MAV_CMD_NAV_LOITER_TIME {#MAV_CMD_NAV_LOITER_TIME}
 
 [MAV_CMD_NAV_LOITER_TIME](../messages/common.md#MAV_CMD_NAV_LOITER_TIME) causes a vehicle to loiter at specified location for a given amount of time after reaching the location.
@@ -73,7 +77,7 @@ Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified 
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
 | 1: Time             | Loiter time (only starts once Lat, Lon and Alt is reached).                                                                                                                                                                                                                                                                                                             | s                       |
 | 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False)                                                                                                                                                                                                                                                                                             | min:0 max:1 increment:1 |
-| 3: Radius           | Radius around waypoint. If positive loiter clockwise, else counter-clockwise                                                                                                                                                                                                                                                                                            | m                       |
+| 3: Radius           | Radius around waypoint (circling vehicles only). If positive loiter clockwise, else counter-clockwise                                                                                                                                                                                                                                                                   | m                       |
 | 4: Xtrack Location  | Sets xtrack path or exit location: `0` for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), `1` to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. |                         |
 | 5: Latitude         | Latitude                                                                                                                                                                                                                                                                                                                                                                |                         |
 | 6: Longitude        | Longitude                                                                                                                                                                                                                                                                                                                                                               |                         |
@@ -85,7 +89,7 @@ Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified 
 The remaining parameters (xtrack and heading) apply only to forward flying aircraft (not multicopters!)
 :::
 
-Xtrack and heading define the location at which a forward flying (fixed wing) vehicle will _exit the loiter circle, and its path to the next waypoint_ (these apply only to `MAV_CMD_NAV_LOITER_TIME` and `MAV_CMD_NAV_LOITER_TURNS`).
+Xtrack and heading define the location at which a forward flying (fixed wing) vehicle will _exit the loiter circle, and its path to the next waypoint_ (these apply to [MAV_CMD_NAV_LOITER_TIME](#MAV_CMD_NAV_LOITER_TIME), [MAV_CMD_NAV_LOITER_TURNS](#MAV_CMD_NAV_LOITER_TURNS), and [MAV_CMD_NAV_LOITER_TO_ALT](#MAV_CMD_NAV_LOITER_TO_ALT)).
 
 The recommended values (and resulting paths) are those shown below.
 
@@ -109,7 +113,7 @@ The Xtrack parameter independently defines the path and exit location:
   - If the heading required parameter is not set it will exit the loiter immediately (note that this exit path does not make much sense unless the heading parameter is set).
 - `xtrack=NaN`: Exit the loiter using "system specific default behaviour".
   - The vehicle must still respect the heading required param.
-  - Usually this is synonymous with `xtrack=0`
+  - Usually this is synonymous with `xtrack=0` <!-- TBD original text - double check later -->
 
 <!--
 #### Autopilot Support
@@ -121,8 +125,7 @@ The Xtrack parameter independently defines the path and exit location:
 
 [MAV_CMD_NAV_LOITER_TURNS](../messages/common.md#MAV_CMD_NAV_LOITER_TURNS) causes a vehicle to loiter at specified location for a given number of turns.
 
-Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
-Multicopter vehicles should similarly circle at the specified radius/direction.
+Vehicles must _circle_ the point with the specified radius/direction (also applies to multicopters if this item is implemented).
 
 #### Params
 
@@ -130,7 +133,7 @@ Multicopter vehicles should similarly circle at the specified radius/direction.
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- |
 | 1: Turns            | Number of turns.                                                                                                                                                                                                                                                                                                                                                                                                   |                         |
 | 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False). See [Exit Conditions](#loiter_exit) above.                                                                                                                                                                                                                                                                                            | min:0 max:1 increment:1 |
-| 3: Radius           | Radius around waypoint. If positive loiter clockwise, else counter-clockwise                                                                                                                                                                                                                                                                                                                                       | m                       |
+| 3: Radius           | Loiter radius around waypoint. If positive loiter clockwise, else counter-clockwise                                                                                                                                                                                                                                                                                                                                | m                       |
 | 4: Xtrack Location  | Sets xtrack path or exit location: `0` for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), `1` to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. See [Exit Conditions](#loiter_exit) above. |                         |
 | 5: Latitude         | Latitude                                                                                                                                                                                                                                                                                                                                                                                                           |                         |
 | 6: Longitude        | Longitude                                                                                                                                                                                                                                                                                                                                                                                                          |                         |
@@ -147,25 +150,25 @@ Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified 
 
 NOTE: Param order differs from the other loiter commands here: Heading Required is param 1 and Radius is param 2, not param 2/3.
 
-| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Units                |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| 1: Heading Required | Leave loiter circle only when track heading towards the next waypoint (MAV_BOOL_TRUE). A value of MAV_BOOL_FALSE causes leaving when altitude is reached. Values not equal to 0 or 1 are invalid. See [Exit Conditions](#loiter_exit) above.                                                                                                                                                                                                                                                         |                      |
-| 2: Radius           | Radius around waypoint. If positive loiter clockwise, else counter-clockwise; `0` means no change to the standard loiter radius.                                                                                                                                                                                                                                                                                                                                                                     | m                    |
-| 3                   | Empty                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |                      |
-| 4: Xtrack Location  | Loiter circle exit location and/or path to next waypoint ("xtrack") for forward-only moving vehicles (not multicopters). 0 for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), 1 to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. See [Exit Conditions](#loiter_exit) above. | min: 0 max: 1 inc: 1 |
-| 5: Latitude         | Latitude (`0` with Longitude `0` means loiter at the current position).                                                                                                                                                                                                                                                                                                                                                                                                                              |                      |
-| 6: Longitude        | Longitude (`0` with Latitude `0` means loiter at the current position).                                                                                                                                                                                                                                                                                                                                                                                                                              |                      |
-| 7: Altitude         | Target altitude — the loiter is not complete until this is reached.                                                                                                                                                                                                                                                                                                                                                                                                                                  | m                    |
+| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | Units                   |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| 1: Heading Required | Leave loiter circle only when track heading towards the next waypoint (MAV_BOOL_TRUE). A value of MAV_BOOL_FALSE causes leaving when altitude is reached. Values not equal to 0 or 1 are invalid. See [Exit Conditions](#loiter_exit) above.                                                                                                                                                                                                                                                         |                         |
+| 2: Radius           | Radius around waypoint (circling vehicles only). If positive loiter clockwise, else counter-clockwise; `0`: no change.                                                                                                                                                                                                                                                                                                                                                                               | m                       |
+| 3                   | -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |                         |
+| 4: Xtrack Location  | Loiter circle exit location and/or path to next waypoint ("xtrack") for forward-only moving vehicles (not multicopters). 0 for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), 1 to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. See [Exit Conditions](#loiter_exit) above. | min:0 max:1 increment:1 |
+| 5: Latitude         | Latitude (`0` with Longitude `0` means loiter at the current position).                                                                                                                                                                                                                                                                                                                                                                                                                              |                         |
+| 6: Longitude        | Longitude (`0` with Latitude `0` means loiter at the current position).                                                                                                                                                                                                                                                                                                                                                                                                                              |                         |
+| 7: Altitude         | Target altitude — the loiter is not complete until this is reached.                                                                                                                                                                                                                                                                                                                                                                                                                                  | m                       |
 
 <!--
-#### Autopilot support
+#### Autopilot Support
 
 - Untested
 -->
 
 ### MAV_CMD_NAV_LOITER_UNLIM {#MAV_CMD_NAV_LOITER_UNLIM}
 
-[MAV_CMD_NAV_LOITER_UNLIM](../messages/common.md#MAV_CMD_NAV_LOITER_UNLIM) - Loiter at specified location for an unlimited amount of time, yawing to face a given direction.
+[MAV_CMD_NAV_LOITER_UNLIM](../messages/common.md#MAV_CMD_NAV_LOITER_UNLIM) causes the vehicle to loiter at the specified location for an unlimited amount of time, yawing to face a given direction.
 
 Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
 Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
@@ -174,9 +177,9 @@ Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified 
 
 | Param (:Label) | Description                                                                                                            | Units |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------- | ----- |
-| 1              | Empty                                                                                                                  |       |
-| 2              | Empty                                                                                                                  |       |
-| 3: Radius      | Radius around waypoint. If positive loiter clockwise, else counter-clockwise                                           | m     |
+| 1              | -                                                                                                                      |       |
+| 2              | -                                                                                                                      |       |
+| 3: Radius      | Radius around waypoint (circling vehicles only). If positive loiter clockwise, else counter-clockwise                  | m     |
 | 4: Yaw         | Desired yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.). | deg   |
 | 5: Latitude    | Latitude                                                                                                               |       |
 | 6: Longitude   | Longitude                                                                                                              |       |
@@ -196,17 +199,17 @@ This can be used for triggering a `DO_*` action (camera, speed change, etc.) at 
 
 #### Params
 
-| Param (:Label) | Description                                                                                    |
-| -------------- | ---------------------------------------------------------------------------------------------- |
-| 1: Geometry    | Geometry of the gate test. `0`: line orthogonal to the path (no other values defined/allowed). |
-| 2: UseAltitude | [MAV_BOOL_TRUE](../messages/common.md#MAV_BOOL) if altitude is included in the crossing test.  |
-| 3:             |                                                                                                |
-| 4:             |                                                                                                |
-| 5: Latitude    | Latitude of the gate.                                                                          |
-| 6: Longitude   | Longitude of the gate.                                                                         |
-| 7: Altitude    | Altitude of the gate.                                                                          |
+| Param (:Label) | Description                                                                                    | Units |
+| -------------- | ---------------------------------------------------------------------------------------------- | ----- |
+| 1: Geometry    | Geometry of the gate test. `0`: line orthogonal to the path (no other values defined/allowed). |       |
+| 2: UseAltitude | [MAV_BOOL_TRUE](../messages/common.md#MAV_BOOL) if altitude is included in the crossing test.  |       |
+| 3              | -                                                                                              |       |
+| 4              | -                                                                                              |       |
+| 5: Latitude    | Latitude of the gate.                                                                          |       |
+| 6: Longitude   | Longitude of the gate.                                                                         |       |
+| 7: Altitude    | Altitude of the gate.                                                                          | m     |
 
-#### Autopilot support
+#### Autopilot Support
 
 ArduPilot:
 

--- a/en/services/mission_item_detail.md
+++ b/en/services/mission_item_detail.md
@@ -59,41 +59,32 @@ PX4:
 
 - _Pass Radius_ (param3) not implemented. A non-default value for param 3 is rejected.
 
-### Loiter Commands (`MAV_CMD_NAV_LOITER_*`) {#loiter_commands}
+### MAV_CMD_NAV_LOITER_TIME {#MAV_CMD_NAV_LOITER_TIME}
 
-Loiter commands are provided to allow a vehicle to hold at a location for a specified time or number of turns, until it reaches the specified altitude, or indefinitely.
+[MAV_CMD_NAV_LOITER_TIME](../messages/common.md#MAV_CMD_NAV_LOITER_TIME) - Loiter at specified location for a given amount of time after reaching the location.
+
 Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
 Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
 
-The commands are:
+#### Params
 
-- [MAV_CMD_NAV_LOITER_TIME](../messages/common.md#MAV_CMD_NAV_LOITER_TIME) - Loiter at specified location for a given amount of time after reaching the location.
-- [MAV_CMD_NAV_LOITER_TURNS](../messages/common.md#MAV_CMD_NAV_LOITER_TURNS) - Loiter at specified location for a given number of turns.
-- [MAV_CMD_NAV_LOITER_TO_ALT](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TO_ALT) - Loiter at specified location until desired altitude is reached.
-- [MAV_CMD_NAV_LOITER_UNLIM](../messages/common.md#MAV_CMD_NAV_LOITER_UNLIM) - Loiter at specified location for an unlimited amount of time, yawing to face a given direction.
+| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                             | Units                   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
+| 1: Time             | Loiter time (only starts once Lat, Lon and Alt is reached).                                                                                                                                                                                                                                                                                                             | s                       |
+| 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False)                                                                                                                                                                                                                                                                                             | min:0 max:1 increment:1 |
+| 3: Radius           | Radius around waypoint. If positive loiter clockwise, else counter-clockwise                                                                                                                                                                                                                                                                                            | m                       |
+| 4: Xtrack Location  | Sets xtrack path or exit location: `0` for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), `1` to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. |                         |
+| 5: Latitude         | Latitude                                                                                                                                                                                                                                                                                                                                                                |                         |
+| 6: Longitude        | Longitude                                                                                                                                                                                                                                                                                                                                                               |                         |
+| 7: Altitude         | Altitude                                                                                                                                                                                                                                                                                                                                                                | m                       |
 
-The location and fixed-wing loiter radius parameters are common to all commands:
-
-| Param (:Label) | Description                                                                  | Units |
-| -------------- | ---------------------------------------------------------------------------- | ----- |
-| 3: Radius      | Radius around waypoint. If positive loiter clockwise, else counter-clockwise | m     |
-| 5: Latitude    | Latitude                                                                     |
-| 6: Longitude   | Longitude                                                                    |
-| 7: Altitude    | Altitude                                                                     | m     |
-
-The loiter time and turns are set in param 1 for the respective messages.
-The direction of loiter for `MAV_CMD_NAV_LOITER_UNLIM` can be set using `param4` (Yaw).
+#### Exit Conditions {#loiter_exit}
 
 ::: info
 The remaining parameters (xtrack and heading) apply only to forward flying aircraft (not multicopters!)
 :::
 
 Xtrack and heading define the location at which a forward flying (fixed wing) vehicle will _exit the loiter circle, and its path to the next waypoint_ (these apply only to `MAV_CMD_NAV_LOITER_TIME` and `MAV_CMD_NAV_LOITER_TURNS`).
-
-| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                             | Units                   |
-| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- |
-| 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False)                                                                                                                                                                                                                                                                                             | min:0 max:1 increment:1 |
-| 4: Xtrack Location  | Sets xtrack path or exit location: `0` for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), `1` to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. |
 
 The recommended values (and resulting paths) are those shown below.
 
@@ -118,6 +109,63 @@ The Xtrack parameter independently defines the path and exit location:
 - `xtrack=NaN`: Exit the loiter using "system specific default behaviour".
   - The vehicle must still respect the heading required param.
   - Usually this is synonymous with `xtrack=0`
+
+### MAV_CMD_NAV_LOITER_TURNS {#MAV_CMD_NAV_LOITER_TURNS}
+
+[MAV_CMD_NAV_LOITER_TURNS](../messages/common.md#MAV_CMD_NAV_LOITER_TURNS) - Loiter at specified location for a given number of turns.
+
+Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
+Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
+
+#### Params
+
+| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                                                                        | Units                   |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------- |
+| 1: Turns            | Number of turns.                                                                                                                                                                                                                                                                                                                                                                                                   |                         |
+| 2: Heading Required | Leave loiter circle only once heading towards the next waypoint (0 = False). See [Exit Conditions](#loiter_exit) above.                                                                                                                                                                                                                                                                                            | min:0 max:1 increment:1 |
+| 3: Radius           | Radius around waypoint. If positive loiter clockwise, else counter-clockwise                                                                                                                                                                                                                                                                                                                                       | m                       |
+| 4: Xtrack Location  | Sets xtrack path or exit location: `0` for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), `1` to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. See [Exit Conditions](#loiter_exit) above. |                         |
+| 5: Latitude         | Latitude                                                                                                                                                                                                                                                                                                                                                                                                           |                         |
+| 6: Longitude        | Longitude                                                                                                                                                                                                                                                                                                                                                                                                          |                         |
+| 7: Altitude         | Altitude                                                                                                                                                                                                                                                                                                                                                                                                           | m                       |
+
+### MAV_CMD_NAV_LOITER_TO_ALT {#MAV_CMD_NAV_LOITER_TO_ALT}
+
+[MAV_CMD_NAV_LOITER_TO_ALT](https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_TO_ALT) - Loiter at specified location until desired altitude is reached.
+
+Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
+Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
+
+#### Params
+
+| Param (:Label)      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                               | Units                |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| 1: Heading Required | Leave loiter circle only when track heading towards the next waypoint (MAV_BOOL_TRUE). A value of MAV_BOOL_FALSE causes leaving when altitude is reached. Values not equal to 0 or 1 are invalid.                                                                                                                                                                                                                                                         |                      |
+| 2: Radius           | Radius around waypoint. If positive loiter clockwise, else counter-clockwise                                                                                                                                                                                                                                                                                                                                                                              | m                    |
+| 3                   | Empty                                                                                                                                                                                                                                                                                                                                                                                                                                                     |                      |
+| 4: Xtrack Location  | Loiter circle exit location and/or path to next waypoint ("xtrack") for forward-only moving vehicles (not multicopters). 0 for the vehicle to converge towards the center xtrack when it leaves the loiter (the line between the centers of the current and next waypoint), 1 to converge to the direct line between the location that the vehicle exits the loiter radius and the next waypoint. NaN to use the current system default xtrack behaviour. | min: 0 max: 1 inc: 1 |
+| 5: Latitude         | Latitude                                                                                                                                                                                                                                                                                                                                                                                                                                                  |                      |
+| 6: Longitude        | Longitude                                                                                                                                                                                                                                                                                                                                                                                                                                                 |                      |
+| 7: Altitude         | Altitude                                                                                                                                                                                                                                                                                                                                                                                                                                                  | m                    |
+
+### MAV_CMD_NAV_LOITER_UNLIM {#MAV_CMD_NAV_LOITER_UNLIM}
+
+[MAV_CMD_NAV_LOITER_UNLIM](../messages/common.md#MAV_CMD_NAV_LOITER_UNLIM) - Loiter at specified location for an unlimited amount of time, yawing to face a given direction.
+
+Multicopter vehicles stop at the specified point (within a _vehicle-specific_ acceptance radius that is not set by the mission item).
+Forward-moving vehicles (e.g. fixed-wing) _circle_ the point with the specified radius/direction.
+
+#### Params
+
+| Param (:Label) | Description                                                                                                            | Units |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------- | ----- |
+| 1              | Empty                                                                                                                  |       |
+| 2              | Empty                                                                                                                  |       |
+| 3: Radius      | Radius around waypoint. If positive loiter clockwise, else counter-clockwise                                           | m     |
+| 4: Yaw         | Desired yaw angle. NaN to use the current system yaw heading mode (e.g. yaw towards next waypoint, yaw to home, etc.). | deg   |
+| 5: Latitude    | Latitude                                                                                                               |       |
+| 6: Longitude   | Longitude                                                                                                              |       |
+| 7: Altitude    | Altitude                                                                                                               | m     |
 
 ## `CONDITION_` Items
 


### PR DESCRIPTION
This add docs for behaviour of mission items.

It pulls the loiter ones that were already documented and adds some waypoint and condition gate.

@peterbarker The gate thing is quite different from a waypoint - its not on the path. 